### PR TITLE
[fix] 어드민 로그인 시 localhost:3001로 이동되는 문제 수정

### DIFF
--- a/apps/client/src/app/AdminRedirect.tsx
+++ b/apps/client/src/app/AdminRedirect.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { cn } from '@repo/utils';
+
+const getAdminUrl = (origin: string): string => {
+  if (origin.includes('localhost')) return 'http://localhost:3001';
+  if (origin.includes('stage')) return 'https://admin.stage.hellogsm.kr';
+  return 'https://admin.hellogsm.kr';
+};
+
+const AdminRedirect = () => {
+  useEffect(() => {
+    window.location.replace(getAdminUrl(window.location.origin));
+  }, []);
+
+  return (
+    <div className={cn('flex', 'h-[calc(100vh-4.625rem)]', 'items-center', 'justify-center')}>
+      <div className={cn('text-lg', 'font-medium')}>이동 중...</div>
+    </div>
+  );
+};
+
+export default AdminRedirect;

--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -1,9 +1,9 @@
-import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { MainPage } from '@/pageContainer';
 import { getIsServerHealthy } from '@/utils';
 
+import AdminRedirect from './AdminRedirect';
 import {
   getMyAuthInfo,
   getMyFirstTestResult,
@@ -25,13 +25,7 @@ export default async function Home({ searchParams }: { searchParams?: { isAdmin?
   const isAdminRole = authInfo?.role === 'ADMIN' || authInfo?.role === 'ROOT';
 
   if (isAdminRequested && isAdminRole) {
-    const host = headers().get('host') ?? '';
-    const adminUrl = host.includes('localhost')
-      ? 'http://localhost:3001'
-      : host.includes('stage')
-        ? 'https://admin.stage.hellogsm.kr'
-        : 'https://admin.hellogsm.kr';
-    redirect(adminUrl);
+    return <AdminRedirect />;
   }
 
   if (authInfo?.authReferrerType && !memberInfo?.name) {


### PR DESCRIPTION
## 개요 💡

스테이지 어드민(`admin.stage.hellogsm.kr`)에서 로그인하면 콜백 처리 후 `http://localhost:3001/`로 이동하던 버그(#418)를 수정합니다.

원인은 #411에서 어드민 도메인 판별을 **환경변수 기반 → 서버 Host 헤더(`headers().get('host')`) 기반**으로 바꾼 데 있습니다. 스테이지는 리버스 프록시를 통해 내부 호스트(`localhost`)를 Host로 전달하므로, `host.includes('localhost')`가 먼저 매칭돼 항상 `localhost:3001`로 리다이렉트됩니다.

## 작업내용 ⌨️

- `apps/client/src/app/AdminRedirect.tsx` 신규 추가
  - 브라우저 주소창 값인 `window.location.origin` 기준으로 어드민 URL을 판별해 리다이렉트하는 클라이언트 컴포넌트
  - localhost → `localhost:3001`, stage → `admin.stage.hellogsm.kr`, 운영 → `admin.hellogsm.kr`
- `apps/client/src/app/page.tsx`
  - 서버 Host 헤더 기반 판별 블록 제거 → `<AdminRedirect />` 렌더로 교체
  - 미사용 `headers` import 제거 (`redirect`는 `/signup` 분기에서 계속 사용)
  - 서버 측 권한 검증(`isAdminRequested && isAdminRole`)은 그대로 유지

### 왜 이 방식인가

`window.location.origin`은 브라우저 주소창 값이라 리버스 프록시의 영향을 받지 않습니다. 또한 이 신호는 이미 동일 플로우의 `LoginButton`(redirectUri 생성)과 `CallbackPage`(`/?isAdmin=true` 생성)에서 정상 동작 중이므로, 검증된 신호를 마지막 리다이렉트에도 그대로 사용하는 변경입니다.

## 관련 이슈 🚨

- Closes #418
- 회귀 원인: #411

## 리뷰 요청사항 👀

- 로컬에서는 정상 동작을 확인했으나, 실제 스테이지 프록시 환경은 배포 후에야 최종 검증이 가능합니다. 스테이지 배포 시 `admin.stage.hellogsm.kr/signin` 로그인 → 콜백 후 `admin.stage.hellogsm.kr`로 복귀하는지 확인 부탁드립니다.

