### PR TITLE
[feat] Ready, GSM 안내 섹션 추가

### DIFF
--- a/apps/client/src/components/MainPage/Section2/index.tsx
+++ b/apps/client/src/components/MainPage/Section2/index.tsx
@@ -76,7 +76,7 @@ const stepsData = [
 
 const Section2 = () => {
   return (
-    <div
+    <section
       id="section2"
       className={cn('w-full', 'bg-white', 'relative', 'py-[11.25rem]', 'overflow-hidden')}
     >
@@ -224,7 +224,14 @@ const Section2 = () => {
           </div>
 
           <div
-            className={cn('flex', 'justify-around', 'mt-[3.25rem]', 'relative', 'hidden', 'lg:flex')}
+            className={cn(
+              'flex',
+              'justify-around',
+              'mt-[3.25rem]',
+              'relative',
+              'hidden',
+              'lg:flex',
+            )}
           >
             {stepsData.slice(4).map((step, index) => (
               <div
@@ -362,7 +369,7 @@ const Section2 = () => {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/apps/client/src/components/MainPage/Section3/index.tsx
+++ b/apps/client/src/components/MainPage/Section3/index.tsx
@@ -22,7 +22,7 @@ interface Section3Props {
 
 const Section3 = ({ isServerHealthy }: Section3Props) => {
   return (
-    <div className={cn('w-full', 'bg-white', 'relative', 'py-[11.25rem]')}>
+    <section className={cn('w-full', 'bg-white', 'relative', 'py-[11.25rem]')}>
       <div
         className={cn(
           'flex',
@@ -84,22 +84,9 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
           )}
         >
           <div
-            className={cn(
-              'grid',
-              'grid-cols-6',
-              'grid-rows-3',
-              'gap-[0.75rem]',
-              'min-h-[39rem]',
-            )}
+            className={cn('grid', 'grid-cols-6', 'grid-rows-3', 'gap-[0.75rem]', 'min-h-[39rem]')}
           >
-            <div
-              className={cn(
-                'col-span-2',
-                'row-span-1',
-                'rounded-[0.75rem]',
-                'bg-lime-400 p-6',
-              )}
-            >
+            <div className={cn('col-span-2', 'row-span-1', 'rounded-[0.75rem]', 'bg-lime-400 p-6')}>
               <div className={cn('flex', 'h-full', 'w-full', 'items-center', 'justify-center')}>
                 <I.StarIcon />
               </div>
@@ -176,7 +163,6 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
                 'p-6',
               )}
               style={{
-                 
                 background: "url('/images/Pattern.png') center / 150% no-repeat",
               }}
             >
@@ -239,13 +225,7 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
               </div>
             </div>
             <div
-              className={cn(
-                'col-span-2',
-                'row-span-1',
-                'rounded-[0.75rem]',
-                'bg-lime-400',
-                'p-6',
-              )}
+              className={cn('col-span-2', 'row-span-1', 'rounded-[0.75rem]', 'bg-lime-400', 'p-6')}
             >
               <div className={cn('flex', 'h-full', 'w-full', 'items-center', 'justify-center')}>
                 <I.Star2Icon />
@@ -254,7 +234,7 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/apps/client/src/components/MainPage/Section5/index.tsx
+++ b/apps/client/src/components/MainPage/Section5/index.tsx
@@ -42,7 +42,9 @@ const Elements = [
 
 const Section5 = () => {
   return (
-    <div className={cn('flex', 'flex-col', 'bg-white', 'py-[11.25rem]', 'w-full')}>
+    <section
+      className={cn('flex', 'flex-col', 'bg-white', 'pt-[11.25rem]', 'pb-[7.5rem]', 'w-full')}
+    >
       <div className={cn('flex', 'justify-center', 'gap-[4.25rem]', 'flex-col')}>
         <div
           className={cn(
@@ -176,7 +178,7 @@ const Section5 = () => {
           ))}
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/apps/client/src/components/MainPage/Section6/index.tsx
+++ b/apps/client/src/components/MainPage/Section6/index.tsx
@@ -30,6 +30,8 @@ const Section6 = () => {
       </h2>
       <a
         href="https://www.ready.hellogsm.kr/"
+        target="_blank"
+        rel="noopener noreferrer"
         className={cn(
           'px-5',
           'py-3',

--- a/apps/client/src/components/MainPage/Section6/index.tsx
+++ b/apps/client/src/components/MainPage/Section6/index.tsx
@@ -1,0 +1,54 @@
+import { cn } from '@repo/utils';
+
+const Section6 = () => {
+  return (
+    <section
+      className={cn(
+        'flex',
+        'flex-col',
+        'items-center',
+        'justify-center',
+        'pb-20',
+        'pt-10',
+        'bg-white',
+        'gap-20',
+      )}
+    >
+      <h2
+        className={cn(
+          'font-bold',
+          'text-[2rem]',
+          'leading-[3rem]',
+          'whitespace-pre-wrap',
+          'text-[#292B2F]',
+          'text-center',
+        )}
+      >
+        광주소프트웨어고등학교에 대해 더 알아보고 싶다면?
+        <br />
+        학과 체험 신청 서비스 <span className={cn('text-[#4A80F8]')}>Ready, GSM</span>도 있습니다
+      </h2>
+      <a
+        href="https://www.ready.hellogsm.kr/"
+        className={cn(
+          'px-5',
+          'py-3',
+          'bg-[#4A80F8]',
+          'text-white',
+          'font-semibold',
+          'rounded-[6.1875rem]',
+          'hover:bg-[#3a6bc8]',
+          'max-w-[23.75rem]',
+          'w-full',
+          'text-center',
+          'text-[18px]',
+          'leading-[1.575rem]',
+        )}
+      >
+        Ready, GSM으로 이동하기
+      </a>
+    </section>
+  );
+};
+
+export default Section6;

--- a/apps/client/src/components/MainPage/index.ts
+++ b/apps/client/src/components/MainPage/index.ts
@@ -3,3 +3,4 @@ export { default as Section2 } from './Section2';
 export { default as Section3 } from './Section3';
 export { default as Section4 } from './Section4';
 export { default as Section5 } from './Section5';
+export { default as Section6 } from './Section6';

--- a/apps/client/src/pageContainer/MainPage/index.tsx
+++ b/apps/client/src/pageContainer/MainPage/index.tsx
@@ -13,6 +13,7 @@ import {
   Section3,
   Section4,
   Section5,
+  Section6,
   TestResultDialog,
 } from '@/components';
 
@@ -48,8 +49,9 @@ const MainPage = ({ memberInfo, resultInfo, isServerHealthy }: MainPageProps) =>
       <Section2 />
       <Section3 isServerHealthy={isServerHealthy} />
       <Section4 />
-      
       <Section5 />
+      <Section6 />
+
       <Footer />
       <TestResultDialog
         isOpen={isOpen}


### PR DESCRIPTION
## 개요 💡

메인 페이지 하단에 Ready, GSM 학과 체험 신청 서비스 안내와 이동 CTA를 추가합니다.

## 작업내용 ⌨️

- Ready, GSM 이동 버튼이 포함된 Section6 추가
- 기존 메인 섹션의 시맨틱 태그 정리 및 하단 여백 조정

## 스크린샷/동영상 📸

<img width="1512" height="982" alt="스크린샷 2026-08-16 오후 10 06 01" src="https://github.com/user-attachments/assets/84734560-e48a-49bd-b7bc-f77560bd81a4" />

## 리뷰 요청사항 👀

- 랜딩 페이지 하단의 문구와 간격을 확인해주세요.

## 검증

- `pnpm --filter client lint`
- `pnpm --filter client check-types`