### PR TITLE
[fix] 메인·안내 페이지 모집 연도 및 전형 일정 표기 수정

### DIFF
--- a/apps/client/src/components/MainPage/Section2/index.tsx
+++ b/apps/client/src/components/MainPage/Section2/index.tsx
@@ -119,7 +119,7 @@ const Section2 = () => {
             >
               광주소프트웨어마이스터고등학교
               <br />
-              2026 신입생 모집절차
+              2027 신입생 모집절차
             </h1>
             <div className={cn('flex', 'flex-col', 'gap-2')}>
               <p

--- a/apps/client/src/components/MainPage/Section3/index.tsx
+++ b/apps/client/src/components/MainPage/Section3/index.tsx
@@ -52,7 +52,7 @@ const Section3 = ({ isServerHealthy }: Section3Props) => {
           >
             광주소프트웨어마이스터고등학교
             <br />
-            2026 신입생 모집
+            2027 신입생 모집
           </h1>
           <p className={cn('mb-0', 'lg:mb-8', 'mt-[1rem]', 'hidden', 'smx:flex', 'text-gray-500')}>
             접수 기간: {ADMISSION_SCHEDULE.submission.startLabel} ~{' '}

--- a/apps/client/src/components/PassResultDialog/index.tsx
+++ b/apps/client/src/components/PassResultDialog/index.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import { ADMISSION_SCHEDULE } from '@repo/constants';
 import { Majors, MyMemberInfoType, MyTotalTestResultType } from '@repo/types';
 import { Button, Dialog, DialogContent, DialogTitle } from '@repo/ui/shadcn';
 import { cn } from '@repo/utils';
@@ -47,7 +48,7 @@ const PassResultDialog = ({
       ),
       message: (
         <>
-          2차 역량검사는 10월 31일 13:00 ~ 16:30에 진행될 예정입니다.
+          2차 역량검사는 {ADMISSION_SCHEDULE.competencyEvaluation.dialogLabel}에 진행될 예정입니다.
           <br />
           <div className={cn('flex', 'items-center', 'gap-1')}>
             <CopyIcon color="#2563EB" />

--- a/apps/client/src/pageContainer/GuidePage/index.tsx
+++ b/apps/client/src/pageContainer/GuidePage/index.tsx
@@ -11,6 +11,7 @@ import {
   useGetMyOneseo,
 } from '@repo/api/hooks';
 import { oneseoQueryKeys } from '@repo/api/lib';
+import { ADMISSION_SCHEDULE } from '@repo/constants';
 import { useModalStore } from '@repo/store';
 import { EditabilityType, GetMyOneseoType } from '@repo/types';
 import { Button } from '@repo/ui/shadcn';
@@ -92,7 +93,7 @@ const Elements: ElementType[] = [
       <>
         서류를 출력 후 확인 부분에 서명 후{' '}
         <strong className={cn('text-blue-500', 'font-semibold')}>
-          10월 20일 ~ 10월 23일 (16:30)까지
+          {ADMISSION_SCHEDULE.submission.guideLabel}
         </strong>{' '}
         해당 서류를 원서 접수처에 제출합니다.
       </>

--- a/packages/constants/src/date.ts
+++ b/packages/constants/src/date.ts
@@ -17,6 +17,8 @@ export const ADMISSION_SCHEDULE = {
     /** 모집절차 스텝 표기 (client Section2) — 시작/종료 라벨 분리 노출 */
     stepStart: '2026. 10. 19.(월)~',
     stepEnd: '22.(목) 09:00 ~ 17:00',
+    /** 서류 제출 안내 표기 (client GuidePage) — 연도 없이 월·일만 노출 */
+    guideLabel: '10월 19일 ~ 10월 22일 (17:00)까지',
   },
 
   /** 1차 전형 합격자 발표 */
@@ -35,6 +37,8 @@ export const ADMISSION_SCHEDULE = {
     step: '2026. 10. 30.(금) 14:00-16:30',
     /** 확인서 발급일 표기 (admin TicketPage) */
     issueDateLabel: '2026년 10월 30일',
+    /** 1차 합격 안내 다이얼로그 표기 (client PassResultDialog) — 연도 없이 월·일만 노출 */
+    dialogLabel: '10월 30일 14:00 ~ 16:30',
   },
 
   /** 2차 전형 — 심층면접 */

--- a/packages/constants/src/date.ts
+++ b/packages/constants/src/date.ts
@@ -22,7 +22,7 @@ export const ADMISSION_SCHEDULE = {
   /** 1차 전형 합격자 발표 */
   firstAnnouncement: {
     /** 모집절차 스텝 표기 (client Section2) */
-    step: '2025. 10. 27.(화) 10:00',
+    step: '2026. 10. 27.(화) 10:00',
   },
 
   /** 2차 전형 — 역량검사 */

--- a/packages/ui/src/components/register/Step1Register/index.tsx
+++ b/packages/ui/src/components/register/Step1Register/index.tsx
@@ -92,7 +92,7 @@ const Step1Register = ({
 
   const handleZipCodeButtonClick = () =>
     daumPostCode({
-      popupTitle: 'Hello, GSM 2024',
+      popupTitle: 'Hello, GSM 2026',
       onComplete: handleDaumPostCodePopupComplete,
     });
 


### PR DESCRIPTION
## 개요 💡

메인페이지의 모집 연도 표기와 1차 전형 합격자 발표 일정이 갱신되지 않아 잘못된 정보가 안내되고 있어 수정합니다.

`2038c224 feat: 일정 변경`에서 전형 일정을 2025 → 2026으로 일괄 갱신할 때 1차 전형 합격자 발표만 일(日)은 바뀌고 연도가 2025로 남아 있었습니다.

이슈 확인 과정에서 같은 성격의 누락을 추가로 발견해 함께 반영했습니다. 원인은 `ADMISSION_SCHEDULE`을 쓰지 않고 문자열을 직접 박아둔 화면이 남아 있었던 것이라, 상수를 참조하도록 연결해 재발을 막았습니다.

## 작업내용 ⌨️

**이슈 보고 사항**

- `ADMISSION_SCHEDULE.firstAnnouncement.step` 연도 수정 (`2025. 10. 27.(화) 10:00` → `2026. 10. 27.(화) 10:00`)
- 메인 Section2 제목을 `2027 신입생 모집절차`로 수정
- 메인 Section3 제목을 `2027 신입생 모집`으로 수정 (동일하게 누락돼 있어 함께 반영)

**추가로 발견한 누락 (작년 일정 잔존)**

- `date.ts`에 두 화면용 포맷 필드 추가 후 상수 참조로 전환
  - `submission.guideLabel` — GuidePage 원서 제출 기간 (`10월 20일 ~ 10월 23일 (16:30)까지` → `10월 19일 ~ 10월 22일 (17:00)까지`)
  - `competencyEvaluation.dialogLabel` — PassResultDialog 2차 역량검사 안내 (`10월 31일 13:00 ~ 16:30` → `10월 30일 14:00 ~ 16:30`)
- 우편번호 검색 팝업 제목을 `Hello, GSM 2026`으로 갱신 (`2024`로 방치돼 있었음)

> PassResultDialog는 1차 합격자에게 노출되는 안내인데, 기존 값의 10월 31일은 올해 기준 **심층면접일**이라 잘못된 날짜가 안내되고 있었습니다.

## 스크린샷/동영상 📸
<img width="914" height="415" alt="image" src="https://github.com/user-attachments/assets/a7834b9a-ec28-4063-8515-d4545d5c0d1a" />
<img width="1187" height="214" alt="image" src="https://github.com/user-attachments/assets/3f4dd42a-3282-4fa4-95ce-bd2e49a5e706" />
<img width="2284" height="1312" alt="image" src="https://github.com/user-attachments/assets/824a7676-fd4a-44fb-aa5f-cbf5ebf49417" />

## 관련 이슈 🚨

closes #445

## 리뷰 요청사항 👀

- `guideLabel` / `dialogLabel`은 기존 문구 디자인을 유지하려고 연도 없이 월·일만 담았습니다. 필드 네이밍과 분리 방식이 적절한지 봐주세요.

## 검증

- `pnpm --filter client lint` — 0 errors (기존 warning 8건)
- `pnpm --filter client check-types`
- `pnpm --filter @repo/constants check-types`
- `pnpm --filter @repo/ui check-types`
