### PR TITLE
[fix] 졸업자 자유학기제 1학년 성적 입력 추가

### DIFF
--- a/packages/constants/src/artPhysical.ts
+++ b/packages/constants/src/artPhysical.ts
@@ -19,6 +19,15 @@ export const artPhysicalCandidateFreeYearArray = [
   '3학년 1학기',
 ] as const;
 
+export const artPhysicalGraduateFreeSemesterArray = [
+  '1학년 1학기',
+  '1학년 2학기',
+  '2학년 1학기',
+  '2학년 2학기',
+  '3학년 1학기',
+  '3학년 2학기',
+] as const;
+
 export const artPhysicalGraduationIndexArray = [
   { subject: '체육', registerIndexList: [0, 3, 6, 9] },
   { subject: '음악', registerIndexList: [1, 4, 7, 10] },
@@ -29,6 +38,12 @@ export const artPhysicalCandidateFreeSemesterIndexArray = [
   { subject: '체육', registerIndexList: [0, 3, 6, 9, 12] },
   { subject: '음악', registerIndexList: [1, 4, 7, 10, 13] },
   { subject: '미술', registerIndexList: [2, 5, 8, 11, 14] },
+] as const;
+
+export const artPhysicalGraduateFreeSemesterIndexArray = [
+  { subject: '체육', registerIndexList: [0, 3, 6, 9, 12, 15] },
+  { subject: '음악', registerIndexList: [1, 4, 7, 10, 13, 16] },
+  { subject: '미술', registerIndexList: [2, 5, 8, 11, 14, 17] },
 ] as const;
 
 export const artPhysicalCandidateFreeGradeIndexArray = [

--- a/packages/constants/src/artPhysicalUtils.ts
+++ b/packages/constants/src/artPhysicalUtils.ts
@@ -3,6 +3,8 @@ import {
   artPhysicalCandidateFreeSemesterArray,
   artPhysicalCandidateFreeSemesterIndexArray,
   artPhysicalCandidateFreeYearArray,
+  artPhysicalGraduateFreeSemesterArray,
+  artPhysicalGraduateFreeSemesterIndexArray,
   artPhysicalGraduationArray,
   artPhysicalGraduationIndexArray,
 } from './artPhysical';
@@ -24,6 +26,7 @@ export function getArtPhysicalArray({
     if (isFreeSemester) return artPhysicalCandidateFreeSemesterArray;
     if (isFreeGrade) return artPhysicalCandidateFreeYearArray;
   }
+  if (isFreeSemester) return artPhysicalGraduateFreeSemesterArray;
   return artPhysicalGraduationArray;
 }
 
@@ -36,5 +39,6 @@ export function getArtPhysicalIndexArray({
     if (isFreeSemester) return artPhysicalCandidateFreeSemesterIndexArray;
     if (isFreeGrade) return artPhysicalCandidateFreeGradeIndexArray;
   }
+  if (isFreeSemester) return artPhysicalGraduateFreeSemesterIndexArray;
   return artPhysicalGraduationIndexArray;
 }

--- a/packages/ui/src/components/ApplicationPrintPage/ArtsPhysicalTable/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/ArtsPhysicalTable/index.tsx
@@ -10,6 +10,7 @@ const ArtsPhysicalTable = ({ oneseo }: OneseoStatusType) => {
 
   const availableSemesters = semesterArray.filter((semester) => {
     if (oneseo.privacyDetail.graduationType === 'GRADUATE') {
+      if (oneseo.middleSchoolAchievement.liberalSystem === '자유학기제') return true;
       return ['2-1', '2-2', '3-1', '3-2'].includes(semester);
     } else if (oneseo.privacyDetail.graduationType === 'CANDIDATE') {
       return semester !== '3-2';

--- a/packages/ui/src/components/ApplicationPrintPage/GeneralSubjectsTable/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/GeneralSubjectsTable/index.tsx
@@ -24,10 +24,14 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
   const { generalSubjectsScoreDetail } = oneseo.calculatedScore;
   const subjects = [...GENERAL_SUBJECTS, ...(oneseo.middleSchoolAchievement.newSubjects ?? [])];
 
+  const isFreeSemester = oneseo.middleSchoolAchievement.liberalSystem === '자유학기제';
+
   const semesters: SemesterKey[] =
     graduationType === 'CANDIDATE'
       ? ['1_1', '1_2', '2_1', '2_2', '3_1']
-      : ['2_1', '2_2', '3_1', '3_2'];
+      : isFreeSemester
+        ? ['1_1', '1_2', '2_1', '2_2', '3_1', '3_2']
+        : ['2_1', '2_2', '3_1', '3_2'];
 
   return (
     <table className={cn('w-full', 'border', 'border-black', 'text-center')}>

--- a/packages/ui/src/components/ApplicationPrintPage/scoreUtils.ts
+++ b/packages/ui/src/components/ApplicationPrintPage/scoreUtils.ts
@@ -14,6 +14,19 @@ export const getArtPhysicalScores = (oneseo: GetMyOneseoType | PreviewOneseoType
   const isCandidate = graduationType === 'CANDIDATE';
 
   if (isGraduate) {
+    const { liberalSystem } = oneseo.middleSchoolAchievement;
+
+    if (liberalSystem === '자유학기제') {
+      return [
+        achievements.slice(0, 3),
+        achievements.slice(3, 6),
+        achievements.slice(6, 9),
+        achievements.slice(9, 12),
+        achievements.slice(12, 15),
+        achievements.slice(15, 18),
+      ];
+    }
+
     return [
       null,
       null,

--- a/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
+++ b/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
@@ -85,15 +85,15 @@ const ArtPhysicalForm = ({
     isFreeGrade,
   });
 
-  // 학기 수가 달라도 표 전체 폭이 유지되도록 열 너비를 조정한다
-  // 졸업자 자유학기제만 6학기라 6.75 + 6 × 6.25 = 44.25rem 기준으로 열을 좁힌다
+  // 표 전체 폭은 44.25rem(708px) 고정 — 과목명 6.75rem + 학기 영역 37.5rem
+  // 학기 열은 37.5rem을 학기 수로 나눈 값이다 (6학기 6.25 / 4학기 9.375 / 3학기 12.5 / 5학기 7.5)
   const columnWidth = isGraduate
     ? isFreeSemester
       ? 'w-[6.25rem]'
-      : 'w-[9.34rem]'
+      : 'w-[9.375rem]'
     : isFreeGrade
-      ? 'w-[12.46rem]'
-      : 'w-[7.47rem]';
+      ? 'w-[12.5rem]'
+      : 'w-[7.5rem]';
 
   const selectWidth = isGraduate
     ? isFreeSemester

--- a/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
+++ b/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
@@ -45,16 +45,15 @@ const rowStyle = [
   'items-center',
 ];
 
-const getFreeSemesterIndices = (semester: FreeSemesterValueEnum | null, isGraduate: boolean) => {
+const getFreeSemesterIndices = (semester: FreeSemesterValueEnum | null) => {
   if (!semester) return [];
   const semesterParts = semester.split('-');
   const grade = Number(semesterParts[0]);
   const sem = Number(semesterParts[1]);
   if (!Number.isFinite(grade) || !Number.isFinite(sem)) return [];
 
-  // 재학생: 1학년부터 시작 (grade - 1), 졸업자: 2학년부터 시작 (grade - 2)
-  const gradeOffset = isGraduate ? 2 : 1;
-  const semesterNumber = (grade - gradeOffset) * 2 + (sem - 1);
+  // 자유학기제 표는 재학생·졸업자 모두 1학년 1학기부터 시작한다
+  const semesterNumber = (grade - 1) * 2 + (sem - 1);
 
   if (semesterNumber < 0) return []; // 유효하지 않은 학기
   return [semesterNumber * 3, semesterNumber * 3 + 1, semesterNumber * 3 + 2];
@@ -86,15 +85,15 @@ const ArtPhysicalForm = ({
     isFreeGrade,
   });
 
-  const disabledIndices = isFreeSemester ? getFreeSemesterIndices(freeSemester, isGraduate) : [];
+  const disabledIndices = isFreeSemester ? getFreeSemesterIndices(freeSemester) : [];
 
   useEffect(() => {
     if (!isFreeSemester) return;
-    const indices = getFreeSemesterIndices(freeSemester, isGraduate);
+    const indices = getFreeSemesterIndices(freeSemester);
     indices.forEach((index) => {
       setValue(`artsPhysicalAchievement.${index}`, 0);
     });
-  }, [freeSemester, isFreeSemester, isGraduate, setValue]);
+  }, [freeSemester, isFreeSemester, setValue]);
 
   return (
     <div className={cn('flex', 'flex-col', 'w-full')}>

--- a/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
+++ b/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
@@ -85,6 +85,24 @@ const ArtPhysicalForm = ({
     isFreeGrade,
   });
 
+  // 학기 수가 달라도 표 전체 폭이 유지되도록 열 너비를 조정한다
+  // 졸업자 자유학기제만 6학기라 6.75 + 6 × 6.25 = 44.25rem 기준으로 열을 좁힌다
+  const columnWidth = isGraduate
+    ? isFreeSemester
+      ? 'w-[6.25rem]'
+      : 'w-[9.34rem]'
+    : isFreeGrade
+      ? 'w-[12.46rem]'
+      : 'w-[7.47rem]';
+
+  const selectWidth = isGraduate
+    ? isFreeSemester
+      ? 'w-[5.47rem]'
+      : 'w-[7.34rem]'
+    : isFreeGrade
+      ? 'w-[10.46rem]'
+      : 'w-[5.47rem]';
+
   const disabledIndices = isFreeSemester ? getFreeSemesterIndices(freeSemester) : [];
 
   useEffect(() => {
@@ -109,13 +127,7 @@ const ArtPhysicalForm = ({
         <h1 className={cn([...itemStyle, 'w-[6.75rem]'])}>과목명</h1>
         <div className={cn('flex')}>
           {artPhysicalArray.map((title) => (
-            <h1
-              key={title}
-              className={cn([
-                ...itemStyle,
-                isGraduate ? 'w-[9.34rem]' : isFreeGrade ? 'w-[12.46rem]' : 'w-[7.47rem]',
-              ])}
-            >
+            <h1 key={title} className={cn([...itemStyle, columnWidth])}>
               {title}
             </h1>
           ))}
@@ -140,13 +152,7 @@ const ArtPhysicalForm = ({
               const isDisabled = disabledIndices.includes(registerIndex);
 
               return (
-                <div
-                  key={registerIndex}
-                  className={cn([
-                    ...itemStyle,
-                    isGraduate ? 'w-[9.34rem]' : isFreeGrade ? 'w-[12.46rem]' : 'w-[7.47rem]',
-                  ])}
-                >
+                <div key={registerIndex} className={cn([...itemStyle, columnWidth])}>
                   {isDisabled ? (
                     <div
                       className={cn(
@@ -180,7 +186,7 @@ const ArtPhysicalForm = ({
                           'text-slate-900',
                           'px-[0.5rem]',
                           'border-slate-300',
-                          isGraduate ? 'w-[7.34rem]' : isFreeGrade ? 'w-[10.46rem]' : 'w-[5.47rem]',
+                          selectWidth,
                           score === undefined && showError && '!border-red-600',
                         ])}
                       >

--- a/packages/ui/src/components/form/FreeGradeForm/index.tsx
+++ b/packages/ui/src/components/form/FreeGradeForm/index.tsx
@@ -109,7 +109,7 @@ const FreeGradeForm = ({
           {achievementList.map(({ title }) => (
             <h1
               key={title}
-              className={cn([...itemStyle, isGraduate ? 'w-[9.34rem]' : 'w-[12.46rem]'])}
+              className={cn([...itemStyle, isGraduate ? 'w-[9.375rem]' : 'w-[12.5rem]'])}
             >
               {title}
             </h1>

--- a/packages/ui/src/components/form/FreeSemesterForm/index.tsx
+++ b/packages/ui/src/components/form/FreeSemesterForm/index.tsx
@@ -99,6 +99,10 @@ const FreeSemesterForm = ({
   // 훅은 map 안에서 호출할 수 없으므로 학기별 배열 전체를 한 번 구독하고 인덱싱한다
   const achievements = useWatch({ control, name: ACHIEVEMENT_FIELD_LIST });
 
+  // 학기 수가 달라도 표 전체 폭이 유지되도록 열 너비를 조정한다
+  // 졸업자 6학기: 6.75 + 6 × 6.25 = 44.25rem, 재학생 5학기: 6.75 + 5 × 7.475 = 44.125rem
+  const columnWidth = isGraduate ? 'w-[6.25rem]' : 'w-[7.475rem]';
+
   useEffect(() => {
     setTimeout(
       () =>
@@ -146,10 +150,7 @@ const FreeSemesterForm = ({
         <h1 className={cn([...itemStyle, 'w-[6.75rem]'])}>과목명</h1>
         <div className={cn('flex')}>
           {achievementList.map(({ title }) => (
-            <h1
-              key={title}
-              className={cn([...itemStyle, isGraduate ? 'w-[9.34375rem]' : 'w-[7.475rem]'])}
-            >
+            <h1 key={title} className={cn([...itemStyle, columnWidth])}>
               {title}
             </h1>
           ))}
@@ -160,10 +161,7 @@ const FreeSemesterForm = ({
         <h1 className={cn([...itemStyle, 'w-[6.75rem]'])}>자유학기제</h1>
         <div className={cn('flex')}>
           {achievementList.map(({ value, field }) => (
-            <div
-              key={field}
-              className={cn([...itemStyle, isGraduate ? 'w-[9.34375rem]' : 'w-[7.475rem]'])}
-            >
+            <div key={field} className={cn([...itemStyle, columnWidth])}>
               {freeSemester === value ? (
                 <button
                   className={cn([
@@ -248,10 +246,7 @@ const FreeSemesterForm = ({
                 const isSubjectError = subjectHasError && showError && '!border-red-600';
 
                 return (
-                  <div
-                    key={field}
-                    className={cn([...itemStyle, isGraduate ? 'w-[9.34375rem]' : 'w-[7.475rem]'])}
-                  >
+                  <div key={field} className={cn([...itemStyle, columnWidth])}>
                     {freeSemester === value ? (
                       <div
                         className={cn(
@@ -268,7 +263,7 @@ const FreeSemesterForm = ({
                         자유학기제
                       </div>
                     ) : (
-                      <div className={cn('w-[7.3375rem]', 'flex', 'justify-center')}>
+                      <div className={cn(columnWidth, 'flex', 'justify-center')}>
                         <Select
                           onValueChange={(value) => {
                             const prev = getValues(field) || [];
@@ -286,7 +281,7 @@ const FreeSemesterForm = ({
                         >
                           <SelectTrigger
                             className={cn(
-                              isGraduate ? 'w-[7.34375rem]' : 'w-[5.475rem]',
+                              'w-[5.475rem]',
                               'h-[2rem]',
                               'text-sm',
                               'font-normal',

--- a/packages/ui/src/components/form/FreeSemesterForm/index.tsx
+++ b/packages/ui/src/components/form/FreeSemesterForm/index.tsx
@@ -99,9 +99,9 @@ const FreeSemesterForm = ({
   // 훅은 map 안에서 호출할 수 없으므로 학기별 배열 전체를 한 번 구독하고 인덱싱한다
   const achievements = useWatch({ control, name: ACHIEVEMENT_FIELD_LIST });
 
-  // 학기 수가 달라도 표 전체 폭이 유지되도록 열 너비를 조정한다
-  // 졸업자 6학기: 6.75 + 6 × 6.25 = 44.25rem, 재학생 5학기: 6.75 + 5 × 7.475 = 44.125rem
-  const columnWidth = isGraduate ? 'w-[6.25rem]' : 'w-[7.475rem]';
+  // 표 전체 폭은 44.25rem(708px) 고정 — 과목명 6.75rem + 학기 영역 37.5rem
+  // 학기 열은 37.5rem을 학기 수로 나눈 값이다 (졸업자 6학기, 재학생 5학기)
+  const columnWidth = isGraduate ? 'w-[6.25rem]' : 'w-[7.5rem]';
 
   useEffect(() => {
     setTimeout(

--- a/packages/ui/src/components/form/NonSubjectForm/index.tsx
+++ b/packages/ui/src/components/form/NonSubjectForm/index.tsx
@@ -10,8 +10,6 @@ interface NonSubjectFormProps {
   register: UseFormRegister<Step4FormType>;
   trigger: UseFormTrigger<Step4FormType>;
   errors: FieldErrors<Step4FormType>;
-  isFreeGrade: boolean;
-  isGraduate: boolean;
   showError: boolean;
   validateForm: () => void;
 }
@@ -56,14 +54,7 @@ const rowStyle = [
   'items-center',
 ];
 
-const NonSubjectForm = ({
-  register,
-  errors,
-  isFreeGrade,
-  isGraduate,
-  showError,
-  validateForm,
-}: NonSubjectFormProps) => {
+const NonSubjectForm = ({ register, errors, showError, validateForm }: NonSubjectFormProps) => {
   useEffect(() => {
     if (!showError) return;
 
@@ -88,11 +79,7 @@ const NonSubjectForm = ({
               key={title}
               className={cn([
                 ...itemStyle,
-                idx === volunteerTimeIndex
-                  ? isFreeGrade || isGraduate
-                    ? 'w-[14.895625rem]'
-                    : 'w-[14.875rem]'
-                  : 'w-[5.625rem]',
+                idx === volunteerTimeIndex ? 'w-[15rem]' : 'w-[5.625rem]',
               ])}
             >
               {title}
@@ -130,11 +117,7 @@ const NonSubjectForm = ({
                   className={cn([
                     ...itemStyle,
                     'px-[0.75rem]',
-                    idx === volunteerTimeIndex
-                      ? isFreeGrade || isGraduate
-                        ? 'w-[14.895625rem]'
-                        : 'w-[14.875rem]'
-                      : 'w-[5.625rem]',
+                    idx === volunteerTimeIndex ? 'w-[15rem]' : 'w-[5.625rem]',
                   ])}
                 >
                   <input

--- a/packages/ui/src/components/register/Step4Register/index.tsx
+++ b/packages/ui/src/components/register/Step4Register/index.tsx
@@ -89,6 +89,16 @@ const freeSemesterCandidateArray = [
 
 const freeSemesterGraduateArray = [
   {
+    title: '1학년 1학기',
+    field: 'achievement1_1',
+    value: FreeSemesterValueEnum['1-1'],
+  },
+  {
+    title: '1학년 2학기',
+    field: 'achievement1_2',
+    value: FreeSemesterValueEnum['1-2'],
+  },
+  {
     title: '2학년 1학기',
     field: 'achievement2_1',
     value: FreeSemesterValueEnum['2-1'],

--- a/packages/ui/src/components/register/Step4Register/index.tsx
+++ b/packages/ui/src/components/register/Step4Register/index.tsx
@@ -1,4 +1,3 @@
- 
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
@@ -458,8 +457,6 @@ const Step4Register = ({
                     register={register}
                     trigger={trigger}
                     errors={formState.errors}
-                    isFreeGrade={isFreeGrade}
-                    isGraduate={isGraduate}
                     showError={showError}
                     validateForm={validateForm}
                   />


### PR DESCRIPTION
## 개요 💡

입시요강이 바뀌어 졸업자도 1학년 성적을 제출하게 되면서, 졸업자 자유학기제의 성적 입력 표에 1학년 1·2학기를 추가합니다.

기존에는 졸업자의 학기 목록이 자유학기제·자유학년제 모두 `2-1 ~ 3-2` 4학기로 고정돼 있었습니다. 그래서 졸업자로 자유학기제를 선택해도 자유학년제와 완전히 동일한 표가 나오고, 요청 payload에도 `achievement1_1` / `achievement1_2`가 항상 `null`로 나갔습니다.

학기 구성을 정하는 상수를 모의 성적 계산·원서 접수·어드민이 공유하고 있어 세 화면에 함께 반영됩니다.

**자유학년제는 이번 변경에서 제외했습니다.** 1학년 전체가 성적 미산출 구간이라 1학년 성적을 어떤 방식으로 받을지 정해진 뒤에 다루는 것이 맞다고 판단했습니다.

## 작업내용 ⌨️

**일반교과** (`a695db4d`)

- `freeSemesterGraduateArray`에 `1-1`, `1-2` 추가 (4학기 → 6학기)
- 자유학기 지정 핀도 1학년에 찍을 수 있게 됩니다. 자유학기제는 통상 1학년에 운영되므로 오히려 실제 운영과 맞습니다

**예체능교과** (`4784c054`)

- 졸업자 자유학기제용 `artPhysicalGraduateFreeSemesterArray` / `artPhysicalGraduateFreeSemesterIndexArray` 추가 (6학기 · 인덱스 18개)
- `getArtPhysicalArray` / `getArtPhysicalIndexArray`에 `GRADUATE + 자유학기제` 분기 추가
- `getFreeSemesterIndices`의 학년 오프셋 분기 제거 — 자유학기제 표가 재학생·졸업자 모두 1학년 1학기부터 시작하게 되어 `isGraduate ? 2 : 1` 보정이 필요 없어졌습니다. 이 보정이 남아 있으면 자유학기로 지정한 학기와 예체능에서 회색 처리되는 칸이 어긋납니다

**원서 출력 성적표** (`fdbdf340`)

- `GeneralSubjectsTable` / `ArtsPhysicalTable`의 학기 목록, `scoreUtils.getArtPhysicalScores`의 예체능 점수 슬라이스가 졸업자를 `2-1`부터로 하드코딩하고 있어, 졸업자 자유학기제일 때 1학년 1학기부터 6개 학기를 쓰도록 수정
- 이걸 빠뜨리면 1학년 성적이 제출돼도 출력물에서 학기가 한 칸씩 밀려 표시됩니다

**표 너비** (`971ba68b`)

- 학기가 6개로 늘면서 표가 1005px까지 넓어져 레이아웃(66.5rem 컨테이너)을 벗어나던 문제 수정
- 학기 열을 100px로 좁혀 과목명 열(108px)과 합쳐 708px로 맞춤. 일반교과·예체능 표에 동일 적용
- 세 곳에 반복되던 너비 삼항식을 `columnWidth` / `selectWidth` 변수로 정리

**표 너비 통일** (`233276de`)

열 너비가 손으로 반올림한 값이라 학기 수를 곱할 때마다 표 전체 폭이 달라졌습니다. 같은 4열 레이아웃인데도 `FreeSemesterForm`은 `9.34375rem`, `FreeGradeForm`·`ArtPhysicalForm`은 `9.34rem`을 쓰고 있었습니다.

| 화면 | 일반교과 | 예체능 | 비교과 | 최대 차이 |
|---|---|---|---|---|
| 재학생 · 자유학기제 | 706.0 | 705.6 | 706.0 | 0.40px |
| 재학생 · 자유학년제 | 706.08 | 706.08 | 706.33 | 0.25px |
| 졸업자 · 자유학년제 | 705.76 | 705.76 | 706.33 | 0.57px |
| 졸업자 · 자유학기제 (6열 추가 후) | 708.0 | 708.0 | 706.33 | 1.67px |

원래도 어긋나 있었지만 0.6px 미만이라 티가 나지 않았고, 6열 표가 들어오면서 처음으로 눈에 띄는 차이가 생겼습니다.

학기 영역을 **37.5rem(600px)** 으로 고정해 학기 수로 나누어떨어지게 하고, 과목명 열 6.75rem과 합쳐 모든 표를 **44.25rem(708px)** 으로 맞췄습니다.

- 3학기 `12.46` → `12.5rem` (200px)
- 4학기 `9.34` → `9.375rem` (150px)
- 5학기 `7.47` → `7.5rem` (120px)
- 6학기 `6.25rem` (100px) — 변경 없음
- 비교과 봉사활동 열 `14.895625`/`14.875` → `15rem` (240px). 값이 같아져 `isFreeGrade`·`isGraduate` 분기가 사라지므로 두 prop을 제거했습니다

## 관련 이슈 🚨

closes #447

## 리뷰 요청사항 👀

- **자유학년제 제외 판단**이 맞는지 봐주세요. 졸업자 자유학년제(`freeGradeGraduateArray`)는 `2-1 ~ 3-2` 그대로입니다.
- **예체능 인덱스 배열**이 일반교과 학기 순서와 정확히 대응하는지 확인 부탁드립니다. 체육 `[0,3,6,9,12,15]` / 음악 `[1,4,7,10,13,16]` / 미술 `[2,5,8,11,14,17]` 로 학기당 3과목씩 이어붙인 구조입니다.
- **표 너비 708px 통일** (`233276de`) — 리뷰 지적을 받아 추가 반영했습니다. 근거는 위 `표 너비 통일` 항목에 정리했습니다.
- `step4Schema`의 `artsPhysicalAchievement` 최소 길이가 `ARTS_PHYSICAL_SUBJECTS.length * 3 = 9`로 고정돼 있어, 학기가 6개(18칸)로 늘어난 지금도 뒤쪽 칸을 비운 채 통과할 수 있습니다. 재학생 자유학기제(15칸)도 동일한 기존 문제라 이번 PR 범위에서는 손대지 않았습니다.

## 참고: 별개로 확인된 백엔드 이슈

이 PR을 검증하다 발견한 건으로, **프론트에서 고칠 수 있는 부분이 아니라 이 PR에는 포함하지 않았습니다.**

졸업자 · 자유학기제 · `freeSemester: "1-2"` 로 저장하면

- 요청: `achievement1_1` 에 성적, `achievement1_2` 는 `null`
- 조회: `achievement1_1` 이 `null`, `achievement1_2` 에 그 값

자유학기 학기의 성적을 채우는 보정이 원본을 남기지 않고 옮기는 것으로 보입니다. 이 상태에서는 원서 출력에서 1학년이 통째로 비어 보입니다 (`1-2`는 자유학기라 빗금, `1-1`은 값이 없어 빗금). 별도 이슈로 등록해 백엔드에서 다룰 예정입니다.

## 검증

- `pnpm --filter @repo/ui check-types`
- `pnpm --filter @repo/constants check-types`
- `pnpm --filter client check-types`
- `pnpm --filter @repo/ui lint` — 0 errors (기존 warning 18건)
- `pnpm --filter @repo/constants lint` — 0 errors

> 로컬에서 실제 화면 확인은 이슈 제보자(작성자)가 step 4에서 1학년 입력 칸이 정상 노출되는 것까지 확인했습니다. 원서 출력물의 1학년 표시는 위 백엔드 이슈가 해결돼야 최종 확인이 가능합니다.


