### PR TITLE
[feat] 생기부 PDF 자동입력(OCR) 기능 추가

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -22,6 +22,7 @@
     "@sentry/nextjs": "^10.69.0",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.5",
+    "kordoc": "^4.9.1",
     "next": "^16.2.10",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/client/src/app/api/school-record-ocr/route.ts
+++ b/apps/client/src/app/api/school-record-ocr/route.ts
@@ -1,5 +1,8 @@
 import { parse } from 'kordoc';
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
+
+import { memberUrl } from '@repo/api/lib';
 
 import { convertKordocBlocks } from '@/lib/kordoc/achievementTextConverter';
 
@@ -14,7 +17,39 @@ const MAX_FILE_SIZE = 20 * 1024 * 1024;
 const errorResponse = (message: string, status: number) =>
   NextResponse.json({ code: status, message, status: `${status}` }, { status });
 
+/**
+ * 이 라우트는 인증·요청 제한 없이 그대로 두면 로그인 없이도 누구나 20MB짜리 OCR을 돌릴 수 있어
+ * 리소스 남용에 노출된다(리뷰 지적). kordoc을 실행하기 전에 로그인 페이지들이 쓰는 것과 같은
+ * SESSION 쿠키를 백엔드 인증 확인 엔드포인트로 검증해 비로그인 요청을 걷어낸다. 요청 빈도
+ * 제한(rate limit)은 이 라우트 코드가 아니라 인프라(Vercel/백엔드) 쪽에서 적용하기로 했다.
+ */
+const isAuthenticated = async (): Promise<boolean> => {
+  const session = (await cookies()).get('SESSION')?.value;
+  if (!session) return false;
+
+  try {
+    const response = await fetch(
+      new URL(memberUrl.getMyAuthInfo(), process.env.NEXT_PUBLIC_API_BASE_URL),
+      {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `SESSION=${session}`,
+        },
+      },
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+};
+
 export async function POST(request: NextRequest) {
+  if (!(await isAuthenticated())) {
+    return errorResponse('로그인이 필요합니다.', 401);
+  }
+
   const formData = await request.formData();
   const file = formData.get('file');
 

--- a/apps/client/src/app/api/school-record-ocr/route.ts
+++ b/apps/client/src/app/api/school-record-ocr/route.ts
@@ -67,7 +67,17 @@ export async function POST(request: NextRequest) {
 
   const buffer = Buffer.from(await file.arrayBuffer());
 
-  const result = await parse(buffer, { ocr: true, tables: true });
+  // 손상되거나 암호화된 PDF는 kordoc이 ParseFailure로 감싸 돌려주지 않고 그냥 throw할 수
+  // 있다 — 감싸지 않으면 이 요청이 처리되지 않은 예외로 500이 되어, 사용자에게 "파일을
+  // 다시 시도해달라" 안내 대신 알 수 없는 서버 오류로 보인다.
+  let result;
+  try {
+    result = await parse(buffer, { ocr: true, tables: true });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[school-record-ocr] kordoc 파싱 중 예외 발생', error);
+    return errorResponse('생기부를 인식하지 못했어요. 다른 파일로 시도해주세요.', 422);
+  }
 
   if (!result.success) {
     // eslint-disable-next-line no-console

--- a/apps/client/src/app/api/school-record-ocr/route.ts
+++ b/apps/client/src/app/api/school-record-ocr/route.ts
@@ -1,0 +1,72 @@
+import { parse } from 'kordoc';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { convertKordocBlocks } from '@/lib/kordoc/achievementTextConverter';
+
+// kordoc은 Node 전용 라이브러리(파일 시스템, sharp 네이티브 모듈 등)라 Edge 런타임에서 못 돈다.
+export const runtime = 'nodejs';
+
+const MAX_FILE_SIZE = 20 * 1024 * 1024;
+
+// axiosInstance의 응답 인터셉터가 백엔드(Java) 응답 형식({code, data, message, status})을
+// 가정하고 response.data.data를 꺼내 쓴다. 이 라우트도 같은 형식으로 감싸야 클라이언트의
+// 공용 post() 훅이 그대로 통한다.
+const errorResponse = (message: string, status: number) =>
+  NextResponse.json({ code: status, message, status: `${status}` }, { status });
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  const file = formData.get('file');
+
+  if (!(file instanceof File)) {
+    return errorResponse('파일이 없습니다.', 400);
+  }
+
+  if (file.type !== 'application/pdf') {
+    return errorResponse('PDF 파일만 지원합니다.', 400);
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return errorResponse('파일 용량은 20MB 이하만 지원합니다.', 400);
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  const result = await parse(buffer, { ocr: true, tables: true });
+
+  if (!result.success) {
+    // eslint-disable-next-line no-console
+    console.error('[school-record-ocr] kordoc 파싱 실패', result.error, result.code);
+    return errorResponse('생기부를 인식하지 못했어요. 다른 파일로 시도해주세요.', 422);
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.debug(
+      '[KORDOC-DEBUG] qualitySummary',
+      JSON.stringify(result.qualitySummary),
+      'warnings',
+      JSON.stringify(result.warnings),
+    );
+  }
+
+  const { rawText, unrecognizedSubjectBlobs } = convertKordocBlocks(result.blocks);
+
+  const totalPages = result.qualitySummary?.totalPages ?? result.pageCount ?? 0;
+  const lowTextPageCount = result.qualitySummary?.lowTextPageCount ?? 0;
+  const usedOcr = lowTextPageCount > 0;
+  const hasTextLayer = lowTextPageCount < totalPages;
+
+  return NextResponse.json({
+    code: 200,
+    data: {
+      rawText,
+      unrecognizedSubjectBlobs,
+      hasTextLayer,
+      source: usedOcr ? 'OCR' : 'TEXT_LAYER',
+      pageCount: result.pageCount ?? totalPages,
+    },
+    message: 'OK',
+    status: '200 OK',
+  });
+}

--- a/apps/client/src/lib/kordoc/achievementTextConverter.ts
+++ b/apps/client/src/lib/kordoc/achievementTextConverter.ts
@@ -273,10 +273,7 @@ const inferMissingSemesterDigit = (
  * 학년"을 우선 쓴다 — 헤딩이 아직 안 왔거나(lastGeneralSubjectsGrade가 없으면) 헤딩값을
  * 그대로 쓴다.
  */
-const resolveGradeForRow = (
-  state: ConversionState,
-  subjects: string[],
-): number | undefined => {
+const resolveGradeForRow = (state: ConversionState, subjects: string[]): number | undefined => {
   const isGeneralSubjectsRow = subjects.some((subject) => isGeneralSubject(subject));
   if (isGeneralSubjectsRow) return state.headingGrade;
   return state.lastGeneralSubjectsGrade ?? state.headingGrade;
@@ -301,7 +298,9 @@ const convertTable = (block: IRBlock, state: ConversionState): void => {
     if (inAttendanceTable) {
       const rawCells = cells.map(textOrEmpty);
       if (convertAttendanceRow(cells, state.lines)) {
-        kordocDebug(`[KORDOC-DEBUG] row ${rowIndex}: 출결 행 처리. cells=${JSON.stringify(rawCells)}`);
+        kordocDebug(
+          `[KORDOC-DEBUG] row ${rowIndex}: 출결 행 처리. cells=${JSON.stringify(rawCells)}`,
+        );
         return;
       }
       // 헤딩 행이거나 열 구조를 못 맞춘 행은 그대로 지나가는 줄로 남긴다.
@@ -365,6 +364,10 @@ const convertTable = (block: IRBlock, state: ConversionState): void => {
       `[KORDOC-DEBUG] row ${rowIndex}: 성공. grade=${gradeForRow ?? '(없음)'}(heading=${state.headingGrade ?? '-'},lastGeneral=${state.lastGeneralSubjectsGrade ?? '-'}) semester=${semesterDigit ?? '(없음)'}${usedCarry ? '(이월)' : ownSemesterDigit ? '' : semesterDigit ? '(추론)' : ''} subjects=${JSON.stringify(subjects)} cells=${JSON.stringify(rawCells)}`,
     );
     if (!semesterDigit) return;
+    // 학년을 하나도 확정 못 한 행(첫 [N학년] 헤딩보다 앞서 나온 행 등)을 그대로 출력하면,
+    // 이전에 이미 써넣은 "[N학년]" 줄이 아직 유효한 상태라 서버 파서가 이 학기·과목 줄을
+    // 직전 학년 것으로 잘못 붙여버릴 수 있다(리뷰 지적). 학년이 없으면 이 행 자체를 건너뛴다.
+    if (gradeForRow === undefined) return;
 
     subjects.forEach((subject) => {
       const seen = usedSemestersBySubject.get(subject) ?? new Set<string>();
@@ -372,11 +375,11 @@ const convertTable = (block: IRBlock, state: ConversionState): void => {
       usedSemestersBySubject.set(subject, seen);
     });
 
-    if (subjects.some((subject) => isGeneralSubject(subject)) && gradeForRow !== undefined) {
+    if (subjects.some((subject) => isGeneralSubject(subject))) {
       state.lastGeneralSubjectsGrade = gradeForRow;
     }
 
-    if (gradeForRow !== undefined && gradeForRow !== state.lastEmittedGrade) {
+    if (gradeForRow !== state.lastEmittedGrade) {
       state.lines.push(`[${gradeForRow}학년]`);
       state.lastEmittedGrade = gradeForRow;
     }
@@ -483,5 +486,8 @@ export const convertKordocBlocks = (rawBlocks: IRBlock[]): KordocConversionResul
     `[KORDOC-DEBUG] 최종 rawText (${state.lines.length}줄):\n${state.lines.join('\n')}\n[KORDOC-DEBUG] unrecognizedSubjectBlobs: ${JSON.stringify(state.unrecognizedSubjectBlobs)}`,
   );
 
-  return { rawText: state.lines.join('\n'), unrecognizedSubjectBlobs: state.unrecognizedSubjectBlobs };
+  return {
+    rawText: state.lines.join('\n'),
+    unrecognizedSubjectBlobs: state.unrecognizedSubjectBlobs,
+  };
 };

--- a/apps/client/src/lib/kordoc/achievementTextConverter.ts
+++ b/apps/client/src/lib/kordoc/achievementTextConverter.ts
@@ -1,0 +1,487 @@
+import type { IRBlock, IRCell } from 'kordoc';
+
+import { isGeneralSubject, isStandardSubject, tokenizeSubjects } from './subjectTokenizer';
+
+/**
+ * 이 로그는 생기부 원문 셀 내용을 그대로 찍는다 — 디버깅에는 꼭 필요하지만, 프로덕션에서
+ * 그대로 두면 학생 개인정보가 서버 콘솔 로그에 남는다. 그래서 프로덕션 빌드에서는 아예
+ * 호출을 건너뛴다.
+ */
+const isDebugEnabled = process.env.NODE_ENV !== 'production';
+const kordocDebug = (...args: unknown[]): void => {
+  // eslint-disable-next-line no-console
+  if (isDebugEnabled) console.debug(...args);
+};
+
+/**
+ * kordoc의 표 재구성 결과를 서버(MiddleSchoolRecordParser)가 원래 읽던 줄 형식으로 되돌린다.
+ *
+ * 새로운 파서를 만들지 않고, 이미 실제 생활기록부로 검증된 기존 파서를 그대로 재사용하는 것이
+ * 목표다. 표가 아닌 블록(제목 등)에서 학년 표시를 복원하고, 표 블록의 각 행에서 원점수/성취도
+ * 열(줄바꿈으로 분리됨)과 과목명 열(구분자 없이 붙어 있음)을 찾아 짝을 맞춘다. 어떤 열이
+ * 무엇인지 표에 명시되어 있지 않으므로, 각 열의 텍스트 모양으로 역할을 추정한다.
+ *
+ * 짝을 맞추지 못한 행은 억지로 밀어 넣지 않고 건너뛰며, 그 과목명 원문을
+ * unrecognizedSubjectBlobs로 돌려주어 사용자 검수를 요청한다. 표 모양을 추정하지 못한
+ * 행(출결·봉사 등)은 셀을 그대로 이어붙여 지나가는 줄로 남겨둔다 — 기존 파서의 정규식은
+ * 정확히 일치하는 줄만 소비하므로, 맞지 않는 줄이 섞여도 무시될 뿐 다른 결과를 해치지 않는다.
+ */
+
+// 블록 텍스트 전체가 학년 표시 그 자체일 때만 인정한다. 부분 일치를 허용하면 "2024학년도
+// 생활기록부" 같은 제목이나 "학년별 출결현황" 같은 캡션에도 반응해 엉뚱한 [N학년] 줄을
+// 끼워 넣고, 문서 전체의 학년 판정을 틀어지게 한다.
+const GRADE_HEADING = /^\[?\s*([1-3])?\s*학년\s*]?$/;
+// kordoc이 병합 셀(여러 과목 행)을 하나의 표 행으로 합칠 때, 학기 열도 과목 수만큼 같은
+// 숫자를 이어붙여서 내보낸다(예: 3과목 병합 → "111", 8과목 병합 → "11111111"). 그래서
+// 정확히 한 글자짜리 "1"/"2"만 인정하면 이런 병합 행의 학기를 전부 놓친다. 실제로는
+// 한 행에 서로 다른 학기가 섞여 병합되는 경우도 있어(예: "11111111222") 순수 반복이
+// 아닐 수 있다 — 이때도 놓치지 않도록 1/2로만 이루어진 문자열이면 다수결로 학기를 정한다.
+const SEMESTER_DIGITS = /^[12]+$/;
+// 원점수/과목평균 부분은 선택 사항이다. 예체능처럼 성취도만 있는 과목이 이 표에 섞여
+// 나올 가능성을 배제할 수 없어, 점수 없이 성취도 글자만 있는 줄도 원점수/성취도 열로 인식한다.
+const SCORE_LINE = /^(?:[\d.,\s]+\/[\d.,\s]+\s*(?:\([^)]*\))?\s+)?[A-EP]\s*(?:\(\s*\d+\s*\))?$/;
+// kordoc이 표를 재구성하면 "원점수/과목평균"("91/77.8")과 "성취도(수강자수)"("A(168)")가
+// 서로 다른 열로 분리되어 나온다. SCORE_LINE은 성취도 글자가 있는 열만 인정하므로 원점수
+// 열은 걸러지지 않고 통째로 버려진다 — 실제로는 값이 있는데도 원점수/평균이 빠진 채
+// "국어 A(168)"처럼 등급만 남아 정보 손실이 생긴다. 그래서 원점수 전용 열도 따로 찾아서
+// 있으면 같이 합친다.
+const RAW_SCORE_LINE = /^[\d.,\s]+\/[\d.,\s]+$/;
+const HANGUL = /[가-힣]/g;
+
+/**
+ * 개인정보가 담긴 섹션(인적사항·수상경력·자격증·진로희망·자유학기활동상황·독서활동상황·
+ * 행동특성및종합의견). kordoc은 이 섹션도 다른 섹션과 똑같이 "표 하나"로 넘겨주기 때문에,
+ * convertTable의 원점수/성취도 열 탐지가 실패하면 convertPassthroughRow가 셀 내용을
+ * 그대로 이어붙여 내보낸다 — 그 표가 인적사항(이름·주민번호·주소)이면 그대로 새어나간다.
+ * 이 섹션에 들어있는 동안은 표/문단 어느 것도 처리하지 않고 통째로 건너뛴다.
+ */
+const PII_SECTION_HEADING =
+  /(?:\d+\.\s*)?(?:인적\s*[·ㆍ,]?\s*학적\s*사항|수상\s*경력|자격증\s*(?:및|,)?\s*인증\s*(?:취득)?\s*상황|진로\s*희망\s*사항|자유\s*학기\s*활동\s*상황|독서\s*활동\s*상황|행동\s*특성\s*(?:및|,)?\s*종합\s*의\s*견)/;
+/** 원서에 실제로 쓰는 섹션. 이 헤딩을 만나면 그 이후로 다시 정상 처리한다 */
+const SAFE_SECTION_HEADING =
+  /(?:\d+\.\s*)?(?:출결\s*상황|창의적\s*체험\s*활동\s*상황|교과\s*학습\s*발달\s*상황)/;
+
+export interface KordocConversionResult {
+  rawText: string;
+  unrecognizedSubjectBlobs: string[];
+}
+
+const textOrEmpty = (block: IRBlock | IRCell): string => block.text ?? '';
+
+const nonEmptyLines = (text: string): string[] =>
+  text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+const countHangul = (text: string): number => (text.match(HANGUL) ?? []).length;
+
+/** 원점수/성취도 열: 줄마다 "91/77.8 A(168)" 또는 "A(168)"(성취도만) 형태를 갖는 셀이다 */
+const findScoreCell = (cells: IRCell[]): IRCell | undefined =>
+  cells.find((cell) => {
+    const lines = nonEmptyLines(textOrEmpty(cell));
+    return lines.length > 0 && lines.every((line) => SCORE_LINE.test(line));
+  });
+
+/** 원점수/과목평균 전용 열: 줄마다 "91/77.8" 형태(성취도 글자 없이 숫자만)를 갖는 셀이다 */
+const findRawScoreCell = (cells: IRCell[], scoreCell: IRCell): IRCell | undefined =>
+  cells.find((cell) => {
+    if (cell === scoreCell) return false;
+    const lines = nonEmptyLines(textOrEmpty(cell));
+    return lines.length > 0 && lines.every((line) => RAW_SCORE_LINE.test(line));
+  });
+
+interface SubjectResolution {
+  subjects: string[] | null;
+  /** 실패했을 때 사용자 검수용으로 보여줄 원문(한글이 가장 많은 후보) */
+  fallbackText: string | undefined;
+}
+
+/**
+ * 과목명 열을 찾아 분해한다. 원점수 셀도, 학기 숫자 하나짜리 셀도 아닌 한글 포함 셀들이
+ * 후보인데, "교과"(사회(역사포함)/도덕 같은 상위 분류) 열과 "과목"(국어·역사·수학처럼
+ * 실제 과목) 열이 둘 다 후보에 들어올 수 있다. 교과 열은 분류명이 반복되며 한글 수가
+ * 오히려 더 많은 경우가 흔해서, "한글이 가장 많은 셀 하나"만 믿으면 교과 열을 잘못
+ * 골라 정작 필요한 과목 열을 놓친다.
+ *
+ * 특히 과목이 1개뿐인 행(예체능 성취도 표)에서 이 문제가 심하다 — 토큰 1개짜리는 사전과
+ * 안 맞는 아무 문자열이나 "선택과목 하나"로 쳐서 거의 항상 분해에 "성공"해버리기 때문에,
+ * "예술(음악/미술)"처럼 사전에도 없는 상위 분류 열이 실제 과목 열(예: "음악")보다 먼저
+ * 성공해버려 "음악"이 "예술"로 잘못 뭉개진다. 그래서 한글 수 순서대로 첫 성공을 그냥
+ * 쓰지 않고, 성공하는 후보를 전부 모아 사전에 실제로 있는 표준 과목으로 분해되는 후보를
+ * 최우선으로 삼는다(선택과목으로 추측한 토큰이 적을수록 우선) — 확인된 값이 추측보다 낫다.
+ * 그 다음에야 한글 수(교과보다 과목 열을 더 신뢰하는 기존 휴리스틱)로 승부를 가른다.
+ */
+const resolveSubjects = (
+  cells: IRCell[],
+  scoreCell: IRCell,
+  expectedCount: number,
+): SubjectResolution => {
+  const candidates = cells
+    .filter((cell) => cell !== scoreCell && !SEMESTER_DIGITS.test(textOrEmpty(cell).trim()))
+    .filter((cell) => countHangul(textOrEmpty(cell)) > 0)
+    .sort((a, b) => countHangul(textOrEmpty(b)) - countHangul(textOrEmpty(a)));
+
+  let best: { subjects: string[]; fallbackText: string; guessedCount: number } | undefined;
+
+  for (const candidate of candidates) {
+    const text = textOrEmpty(candidate);
+    const subjects = tokenizeSubjects(text, expectedCount);
+    if (!subjects) continue;
+
+    const guessedCount = subjects.filter((subject) => !isStandardSubject(subject)).length;
+    if (!best || guessedCount < best.guessedCount) {
+      best = { subjects, fallbackText: text, guessedCount };
+      if (guessedCount === 0) break;
+    }
+  }
+
+  if (best) return { subjects: best.subjects, fallbackText: best.fallbackText };
+  return { subjects: null, fallbackText: candidates[0] ? textOrEmpty(candidates[0]) : undefined };
+};
+
+/** "1"/"2"로만 이루어진 문자열에서 더 많이 나온 숫자를 고른다(병합 행에 서로 다른 학기가 섞인 경우 대비) */
+const majoritySemesterDigit = (digits: string): string => {
+  const oneCount = (digits.match(/1/g) ?? []).length;
+  const twoCount = digits.length - oneCount;
+  return oneCount >= twoCount ? '1' : '2';
+};
+
+/** 학기 칸의 원문(다수결 적용 전)을 그대로 돌려준다 — 길이가 과목 수와 안 맞을 때 잘라 쓰기 위함 */
+const findSemesterDigitString = (cells: IRCell[]): string | undefined => {
+  for (const cell of cells) {
+    const text = textOrEmpty(cell).trim();
+    if (SEMESTER_DIGITS.test(text)) return text;
+  }
+  return undefined;
+};
+
+/** 원점수/성취도 열을 찾지 못한 행(봉사 등으로 추정)은 셀을 이어붙여 지나가는 줄로 남긴다 */
+const convertPassthroughRow = (cells: IRCell[], lines: string[]): void => {
+  const joined = cells
+    .map((cell) => textOrEmpty(cell))
+    .filter((text) => text.trim().length > 0)
+    .join(' ');
+  if (joined.trim()) lines.push(joined);
+};
+
+const cellTextAt = (cells: IRCell[], index: number): string => {
+  const cell = cells[index];
+  return cell ? textOrEmpty(cell) : '';
+};
+
+/** 출결상황 표의 열 헤딩. 이 행을 만나면 이후 데이터 행을 출결 전용 형식으로 처리한다 */
+const isAttendanceHeaderRow = (cells: IRCell[]): boolean =>
+  cellTextAt(cells, 0).trim() === '학년' && cellTextAt(cells, 1).trim() === '수업일수';
+
+/**
+ * 출결 데이터 한 칸을 숫자로 바꾼다. 빈 칸이거나 스캔 잡음("."·"•" 같은 표기)이면 결석·지각
+ * 등이 없다는 뜻이므로 0으로 취급한다 — 서버 파서도 실패 시 기본값을 0으로 채우는 것과
+ * 같은 원칙이다("성적은 못 읽으면 null이 되어 빈칸으로 보이는데 출결·봉사만 0으로 채워지고
+ * 있었다"는 서버 쪽 주석 참고).
+ */
+const toAttendanceCount = (text: string): number => {
+  const trimmed = text.trim();
+  return /^\d+$/.test(trimmed) ? Number(trimmed) : 0;
+};
+
+/**
+ * 출결상황 표는 열이 15개다: 학년, 수업일수, 결석(질병/미인정/기타), 지각(3), 조퇴(3),
+ * 결과(3), 특기사항. 서버 파서는 정확히 "학년 수업일수 [숫자 12개]" 또는 "학년 수업일수
+ * 개근" 형태의 줄만 인식한다(ATTENDANCE_ROW/ATTENDANCE_PERFECT_ROW 정규식). 그런데 이걸
+ * 일반 지나가는 줄 처리(convertPassthroughRow)에 맡기면 빈 칸을 건너뛰고 값이 있는 칸만
+ * 이어붙이기 때문에 숫자 12개가 안 맞고, 스캔 잡음("."·"•")까지 섞여 정규식이 절대
+ * 매칭되지 않는다 — 그러면 그 학년의 결석·지각·조퇴·결과가 전부 빈칸으로 남는다. 그래서
+ * 이 표만은 열 위치를 그대로 지켜서 정해진 형식으로 만든다.
+ */
+const convertAttendanceRow = (cells: IRCell[], lines: string[]): boolean => {
+  const grade = cellTextAt(cells, 0).trim();
+  if (!/^[123]$/.test(grade)) return false;
+
+  const schoolDays = cellTextAt(cells, 1).trim();
+  if (!/^\d+$/.test(schoolDays)) return false;
+
+  const countCells = Array.from({ length: 12 }, (_, index) => cellTextAt(cells, 2 + index));
+  const remark = cellTextAt(cells, 14).trim();
+  const allCountsBlank = countCells.every((text) => text.trim().length === 0);
+
+  if (remark === '개근' && allCountsBlank) {
+    lines.push(`${grade} ${schoolDays} 개근`);
+    return true;
+  }
+
+  const counts = countCells.map(toAttendanceCount);
+  lines.push(`${grade} ${schoolDays} ${counts.join(' ')}`);
+  return true;
+};
+
+interface ConversionState {
+  lines: string[];
+  unrecognizedSubjectBlobs: string[];
+  /** 가장 최근에 본 "[N학년]" 텍스트 블록의 학년 — 하지만 이 값 자체가 잘못된 위치에서
+   * 나올 수 있다(아래 currentGradeForRow 설명 참고), 그래서 단독으로 신뢰하지 않는다. */
+  headingGrade: number | undefined;
+  /** 일반교과(9과목) 행이 마지막으로 성공한 시점의 학년. 예체능·선택과목 행의 학년
+   * 판정에 이 값을 우선 쓴다 — 자세한 이유는 currentGradeForRow 설명 참고. */
+  lastGeneralSubjectsGrade: number | undefined;
+  /** 마지막으로 실제 출력에 써넣은 "[N학년]" 줄의 학년(중복 emit 방지용) */
+  lastEmittedGrade: number | undefined;
+}
+
+/**
+ * 이전에는 행 자체에 학기 숫자가 없으면 직전에 읽은 값을 이어받게 했었다. 하지만 실제
+ * 데이터로 검증해 보니 위험했다: 같은 표 안에서 완전히 빈 학기 칸을 가진 행이 나오면
+ * (예: 1학기 행 바로 뒤에 실제로는 2학기인데 학기 칸이 통째로 비어버린 행), 이어받기가
+ * 직전 행의 학기를 그대로 물려줘서 서로 다른 학기의 점수가 같은 학기로 잘못 찍히고,
+ * 심하면 올바른 점수 위에 다른 학기 점수가 겹쳐 써진다 — 데이터가 비는 것보다 훨씬
+ * 나쁘다. 그래서 행 자체(병합되어 숫자가 반복/혼합됐더라도)에서 학기를 못 찾으면
+ * 기본적으로는 이어받지 않고 건너뛴다.
+ *
+ * 다만 같은 과목이 같은 표 블록 안에 학기 없이 또 나오는 경우(예: 1학기 국어가 이미
+ * "1"로 확정된 뒤, 뒤 행에 학기 칸이 빈 채로 국어·역사·수학이 다른 점수로 또 나오는
+ * 경우)는 안전하게 추론할 수 있다 — 중학교 교과는 학기가 1/2 둘뿐이고 같은 학기 점수가
+ * 중복으로 다시 나올 이유가 없으므로, 그 행의 모든 과목이 이미 정확히 한 학기로만
+ * 확정되어 있고 전부 같은 학기라면 "나머지 학기"로 확정해도 된다. 과목 중 하나라도
+ * 처음 보거나 이미 두 학기 다 나온 상태면(=애매하면) 추론하지 않는다.
+ */
+const inferMissingSemesterDigit = (
+  subjects: string[],
+  usedSemestersBySubject: Map<string, Set<string>>,
+): string | undefined => {
+  const remainingDigits = subjects.map((subject) => {
+    const seen = usedSemestersBySubject.get(subject);
+    if (!seen || seen.size !== 1) return undefined;
+    return seen.has('1') ? '2' : '1';
+  });
+
+  const first = remainingDigits[0];
+  if (!first) return undefined;
+  return remainingDigits.every((digit) => digit === first) ? first : undefined;
+};
+
+/**
+ * 이 행의 진짜 학년을 정한다. "[N학년]" 텍스트가 실제 표보다 blocks 배열에서 먼저 나와
+ * 버리는 kordoc 순서 오류가 실제로 관찰됐다 — 페이지 위치정보(pageNumber/bbox)로
+ * 바로잡으려 했지만, 스캔 OCR 문서는 이 정보 자체가 아예 없어서 그 방법은 쓸 수 없다.
+ *
+ * 대신 문서 구조 자체를 이용한다: "5.교과학습발달상황" 절 안에서 한 학년의 흐름은 항상
+ * [학년 헤딩] → 일반교과 9과목 표(들) → 세부능력특기사항 → 예체능(체육·음악·미술) 표
+ * → 세특 → 교양교과(진로와직업 등 선택) 표 → [다음 학년 헤딩] 순서다. 실제로 틀렸던
+ * 사례는 전부 "예체능/교양교과 표" 앞에 다음 학년 헤딩이 너무 일찍 끼어든 경우였고,
+ * 일반교과 표 자체의 학년 배정은 지금까지 한 번도 틀린 적이 없었다. 그래서 일반교과
+ * 행은 헤딩을 그대로 신뢰하고, 예체능·선택과목 행은 "마지막으로 성공한 일반교과 행의
+ * 학년"을 우선 쓴다 — 헤딩이 아직 안 왔거나(lastGeneralSubjectsGrade가 없으면) 헤딩값을
+ * 그대로 쓴다.
+ */
+const resolveGradeForRow = (
+  state: ConversionState,
+  subjects: string[],
+): number | undefined => {
+  const isGeneralSubjectsRow = subjects.some((subject) => isGeneralSubject(subject));
+  if (isGeneralSubjectsRow) return state.headingGrade;
+  return state.lastGeneralSubjectsGrade ?? state.headingGrade;
+};
+
+const convertTable = (block: IRBlock, state: ConversionState): void => {
+  const rows = block.table?.cells ?? [];
+  // 표 블록 하나 범위로만 기록한다 — 다른 표(다른 학년/다른 표 종류)로 새어 나가면 안 된다.
+  const usedSemestersBySubject = new Map<string, Set<string>>();
+  let inAttendanceTable = false;
+  // 학기 칸 원문이 이 행의 과목 수보다 길면, 실제로는 다음 행의 학기 값이 이 행의 셀에
+  // 잘못 붙어 나온 것이다(실제로 관찰됨: 6과목 행의 학기 칸이 "111111"+다음 행 8과목
+  // 몫인 "22222222"까지 합쳐 14자로 나옴). 초과분을 잘라 다음 행에 넘겨준다 — 길이가
+  // 정확히 그 행의 과목 수와 맞을 때만 사용해서, 근거 없이 다른 행까지 오염시키지 않는다.
+  let pendingSemesterCarry: string | undefined;
+
+  rows.forEach((cells, rowIndex) => {
+    if (isAttendanceHeaderRow(cells)) {
+      inAttendanceTable = true;
+    }
+
+    if (inAttendanceTable) {
+      const rawCells = cells.map(textOrEmpty);
+      if (convertAttendanceRow(cells, state.lines)) {
+        kordocDebug(`[KORDOC-DEBUG] row ${rowIndex}: 출결 행 처리. cells=${JSON.stringify(rawCells)}`);
+        return;
+      }
+      // 헤딩 행이거나 열 구조를 못 맞춘 행은 그대로 지나가는 줄로 남긴다.
+      convertPassthroughRow(cells, state.lines);
+      return;
+    }
+
+    const rawSemesterDigits = findSemesterDigitString(cells);
+
+    const rawCells = cells.map(textOrEmpty);
+    const scoreCell = findScoreCell(cells);
+    if (!scoreCell) {
+      kordocDebug(
+        `[KORDOC-DEBUG] row ${rowIndex}: 원점수/성취도 열 못 찾음 → passthrough. cells=${JSON.stringify(rawCells)}`,
+      );
+      convertPassthroughRow(cells, state.lines);
+      return;
+    }
+
+    const achievementLines = nonEmptyLines(textOrEmpty(scoreCell));
+    const rawScoreCell = findRawScoreCell(cells, scoreCell);
+    const rawScoreLines = rawScoreCell ? nonEmptyLines(textOrEmpty(rawScoreCell)) : [];
+    // 원점수 열이 있어도 줄 수가 성취도 열과 안 맞으면(병합 방식이 서로 다르면) 잘못 짝지어
+    // 합치느니 성취도만 쓰는 게 안전하다.
+    const hasMatchingRawScore = rawScoreLines.length === achievementLines.length;
+    const scoreLines = hasMatchingRawScore
+      ? achievementLines.map((achievement, index) => `${rawScoreLines[index]} ${achievement}`)
+      : achievementLines;
+    const expectedCount = achievementLines.length;
+
+    let ownSemesterDigit: string | undefined;
+    let usedCarry = false;
+    if (rawSemesterDigits && rawSemesterDigits.length > expectedCount) {
+      ownSemesterDigit = majoritySemesterDigit(rawSemesterDigits.slice(0, expectedCount));
+      pendingSemesterCarry = rawSemesterDigits.slice(expectedCount);
+    } else if (rawSemesterDigits) {
+      ownSemesterDigit = majoritySemesterDigit(rawSemesterDigits);
+      pendingSemesterCarry = undefined;
+    } else if (pendingSemesterCarry && pendingSemesterCarry.length === expectedCount) {
+      ownSemesterDigit = majoritySemesterDigit(pendingSemesterCarry);
+      usedCarry = true;
+      pendingSemesterCarry = undefined;
+    } else {
+      pendingSemesterCarry = undefined;
+    }
+
+    const { subjects, fallbackText } = resolveSubjects(cells, scoreCell, expectedCount);
+
+    if (!subjects) {
+      kordocDebug(
+        `[KORDOC-DEBUG] row ${rowIndex}: 과목명 분해 실패. fallbackText=${JSON.stringify(fallbackText)} expectedCount=${scoreLines.length} cells=${JSON.stringify(rawCells)}`,
+      );
+      if (fallbackText) state.unrecognizedSubjectBlobs.push(fallbackText);
+      return;
+    }
+
+    const semesterDigit =
+      ownSemesterDigit ?? inferMissingSemesterDigit(subjects, usedSemestersBySubject);
+    const gradeForRow = resolveGradeForRow(state, subjects);
+    kordocDebug(
+      `[KORDOC-DEBUG] row ${rowIndex}: 성공. grade=${gradeForRow ?? '(없음)'}(heading=${state.headingGrade ?? '-'},lastGeneral=${state.lastGeneralSubjectsGrade ?? '-'}) semester=${semesterDigit ?? '(없음)'}${usedCarry ? '(이월)' : ownSemesterDigit ? '' : semesterDigit ? '(추론)' : ''} subjects=${JSON.stringify(subjects)} cells=${JSON.stringify(rawCells)}`,
+    );
+    if (!semesterDigit) return;
+
+    subjects.forEach((subject) => {
+      const seen = usedSemestersBySubject.get(subject) ?? new Set<string>();
+      seen.add(semesterDigit);
+      usedSemestersBySubject.set(subject, seen);
+    });
+
+    if (subjects.some((subject) => isGeneralSubject(subject)) && gradeForRow !== undefined) {
+      state.lastGeneralSubjectsGrade = gradeForRow;
+    }
+
+    if (gradeForRow !== undefined && gradeForRow !== state.lastEmittedGrade) {
+      state.lines.push(`[${gradeForRow}학년]`);
+      state.lastEmittedGrade = gradeForRow;
+    }
+
+    state.lines.push(semesterDigit);
+
+    subjects.forEach((subject, index) => {
+      state.lines.push(`${subject} ${scoreLines[index]}`);
+    });
+  });
+};
+
+/**
+ * 표가 아닌 블록의 전체 텍스트가 학년 표시(예: "1학년", "[1학년]")뿐일 때만 학년 상태를
+ * 갱신한다. 예전에는 이 자리에서 바로 "[N학년]" 줄을 출력했는데, 이 텍스트 블록 자체가
+ * kordoc 순서상 실제보다 일찍 나올 수 있어(resolveGradeForRow 설명 참고) 그대로 쓰면
+ * 안 된다 — 실제 출력은 각 행을 처리할 때 resolveGradeForRow가 정한 학년으로 한다.
+ */
+const convertHeadingOrText = (block: IRBlock, state: ConversionState): void => {
+  const text = textOrEmpty(block).trim();
+  const match = GRADE_HEADING.exec(text);
+  if (!match || !match[1]) return;
+
+  state.headingGrade = Number(match[1]);
+};
+
+/**
+ * kordoc이 반환하는 blocks 배열의 순서가 실제 PDF의 시각적 읽기 순서(위→아래, 페이지
+ * 순서)와 항상 같지는 않다 — 실제로 확인된 사례: 어떤 PDF에서는 한 페이지 하단의
+ * "[3학년]" 학년 표시 텍스트가, 같은 페이지 상단에 있는(그러니까 아직 2학년 소속인)
+ * 예체능 표보다 blocks 배열에서 먼저 나왔다. 학년/학기 판정은 배열 순서로 "지금까지
+ * 본 마지막 학년 표시"를 추적하는 방식이라, 이 순서가 뒤집히면 2학년 데이터가 통째로
+ * 3학년 것으로 잘못 찍힌다. bbox(페이지+좌표)가 모든 블록에 있으면 그걸로 다시 정렬해
+ * 진짜 읽기 순서를 복원한다 — 일부 블록만 있으면 어설프게 재배치하다 더 망가질 수
+ * 있으니, 전부 있을 때만 정렬하고 아니면 원래 순서를 그대로 믿는다.
+ */
+const sortBlocksByReadingOrder = (blocks: IRBlock[]): IRBlock[] => {
+  const allHavePosition = blocks.every(
+    (block) => block.pageNumber !== undefined && block.bbox !== undefined,
+  );
+  if (!allHavePosition) return blocks;
+
+  return [...blocks].sort((a, b) => {
+    const pageDiff = (a.pageNumber ?? 0) - (b.pageNumber ?? 0);
+    if (pageDiff !== 0) return pageDiff;
+    return (a.bbox?.y ?? 0) - (b.bbox?.y ?? 0);
+  });
+};
+
+export const convertKordocBlocks = (rawBlocks: IRBlock[]): KordocConversionResult => {
+  const state: ConversionState = {
+    lines: [],
+    unrecognizedSubjectBlobs: [],
+    headingGrade: undefined,
+    lastGeneralSubjectsGrade: undefined,
+    lastEmittedGrade: undefined,
+  };
+
+  // 문서 맨 앞(표지·인적사항 등)은 원서에 쓰는 첫 섹션이 나오기 전까지 기본적으로
+  // 건너뛴다 — 어떤 섹션인지 특정하지 못해도 무조건 안전한 쪽으로 취급한다.
+  let seenFirstSafeSection = false;
+  let inSensitiveSection = false;
+  let tableBlockCount = 0;
+
+  const hasPositionInfo = rawBlocks.every(
+    (block) => block.pageNumber !== undefined && block.bbox !== undefined,
+  );
+  const blocks = sortBlocksByReadingOrder(rawBlocks);
+
+  kordocDebug(
+    `[KORDOC-DEBUG] blocks 총 ${blocks.length}개. 위치정보=${hasPositionInfo ? '있음(정렬함)' : '없음(원래 순서 사용)'} 타입별: ${JSON.stringify(
+      blocks.reduce<Record<string, number>>((acc, b) => {
+        acc[b.type] = (acc[b.type] ?? 0) + 1;
+        return acc;
+      }, {}),
+    )}`,
+  );
+
+  for (const block of blocks) {
+    const blockText = textOrEmpty(block);
+    if (SAFE_SECTION_HEADING.test(blockText)) {
+      seenFirstSafeSection = true;
+      inSensitiveSection = false;
+      kordocDebug(`[KORDOC-DEBUG] 안전 섹션 진입: ${JSON.stringify(blockText)}`);
+    } else if (PII_SECTION_HEADING.test(blockText)) {
+      inSensitiveSection = true;
+      kordocDebug(`[KORDOC-DEBUG] 민감 섹션 진입(건너뜀): ${JSON.stringify(blockText)}`);
+    }
+
+    if (!seenFirstSafeSection || inSensitiveSection) continue;
+
+    if (block.type === 'table') {
+      tableBlockCount += 1;
+      kordocDebug(
+        `[KORDOC-DEBUG] table 블록 #${tableBlockCount} 처리 시작. rows=${block.table?.cells.length ?? 0}`,
+      );
+      convertTable(block, state);
+    } else {
+      convertHeadingOrText(block, state);
+    }
+  }
+
+  kordocDebug(
+    `[KORDOC-DEBUG] 최종 rawText (${state.lines.length}줄):\n${state.lines.join('\n')}\n[KORDOC-DEBUG] unrecognizedSubjectBlobs: ${JSON.stringify(state.unrecognizedSubjectBlobs)}`,
+  );
+
+  return { rawText: state.lines.join('\n'), unrecognizedSubjectBlobs: state.unrecognizedSubjectBlobs };
+};

--- a/apps/client/src/lib/kordoc/subjectTokenizer.ts
+++ b/apps/client/src/lib/kordoc/subjectTokenizer.ts
@@ -1,0 +1,121 @@
+import { ARTS_PHYSICAL_SUBJECTS, GENERAL_SUBJECTS } from '@repo/constants';
+
+/**
+ * kordoc이 표를 재구성할 때 과목명 열이 구분자 없이 붙어서 나오는 문제를 해결한다. 예:
+ * "국어역사수학과학기술가정정보영어" → ["국어", "역사", "수학", "과학", "기술가정", "정보", "영어"]
+ *
+ * 표준 과목 사전으로 매칭되는 부분은 그대로 잘라내고, 사전에 없는 구간(한문·생활중국어 같은
+ * 선택과목)은 다음 표준 과목이 시작되는 지점까지를 통째로 선택과목 하나로 묶는다. 예전 버전은
+ * 문자열 전체가 표준 9과목만으로 빈틈없이 나뉘어야만 성공으로 쳐서, 선택과목이 하나라도 섞이면
+ * 그 행 전체(표준 과목 값까지 포함해서)를 통째로 버렸다 — 정부24 생기부는 선택과목이 없는 학기가
+ * 거의 없어서 이게 정확도 저하의 주된 원인이었다.
+ *
+ * 일반교과 9과목뿐 아니라 예체능 3과목(체육·음악·미술)도 사전에 포함한다 — 예체능 표는 한 행에
+ * "체육음악미술"처럼 여러 과목이 붙어 나올 수 있는데, 사전에 없으면 이것도 구분 못 하고 통째로
+ * 선택과목 하나로 뭉쳐버려 개수가 안 맞아 실패한다.
+ */
+
+const DICTIONARY_BY_LENGTH_DESC = [...GENERAL_SUBJECTS, ...ARTS_PHYSICAL_SUBJECTS].sort(
+  (a, b) => b.length - a.length,
+);
+const STANDARD_SUBJECT_SET = new Set<string>(DICTIONARY_BY_LENGTH_DESC);
+const GENERAL_SUBJECT_SET = new Set<string>(GENERAL_SUBJECTS);
+
+/** 분해된 토큰이 사전에 실제로 있는 표준 과목인지(추측이 아니라 확인된 값인지) 확인한다 */
+export const isStandardSubject = (token: string): boolean => STANDARD_SUBJECT_SET.has(token);
+
+/** 일반교과 9과목(국어·사회·도덕·역사·수학·과학·기술가정·정보·영어)인지 확인한다(예체능·선택과 구분용) */
+export const isGeneralSubject = (token: string): boolean => GENERAL_SUBJECT_SET.has(token);
+
+/**
+ * 선택과목 이름 한 개로 인정할 최대 길이. "생활중국어"/"생활일본어"(5자)처럼 실제 선택과목
+ * 이름은 짧다 — 이 상한이 없으면 "교과" 열(같은 분류명이 과목 수만큼 반복되는 열)처럼 전혀
+ * 다른 열도 남는 글자를 통째로 선택과목 하나로 욱여넣어 개수만 맞춰버려 성공한 것처럼
+ * 오판된다.
+ */
+const MAX_ELECTIVE_SUBJECT_LENGTH = 8;
+
+/** 공백·중점 등 표기 장식과 "사회(역사포함)"처럼 과목명에 덧붙는 괄호 설명을 제거한다 */
+const stripDecorations = (raw: string): string =>
+  raw
+    .replace(/\([^)]*\)/g, '')
+    .replace(/[\s·・ㆍ/,~-]/g, '')
+    .trim();
+
+/** position에서 시작하는 표준 과목이 있으면 그 과목명을, 없으면 null을 반환한다 */
+const matchStandardSubjectAt = (text: string, position: number): string | null =>
+  DICTIONARY_BY_LENGTH_DESC.find((subject) => text.startsWith(subject, position)) ?? null;
+
+/** position부터 시작하는, 표준 과목이 매칭되는 모든 지점(오름차순)을 찾는다 */
+const findStandardSubjectStarts = (text: string, from: number): number[] => {
+  const starts: number[] = [];
+  for (let position = from; position < text.length; position += 1) {
+    if (matchStandardSubjectAt(text, position)) starts.push(position);
+  }
+  return starts;
+};
+
+/**
+ * text[start..]를 표준 과목/선택과목 토큰 remainingCount개로 나눈다. 표준 과목이 매칭되면
+ * 우선 사용하고, 매칭되지 않는 구간은 다음 표준 과목이 시작될 수 있는 지점까지를 선택과목
+ * 하나로 묶는다.
+ *
+ * "다음 표준 과목이 시작되는 지점"이 여러 개일 수 있다는 게 까다롭다 — 예를 들어
+ * "생활중국어"는 사전에 없는 선택과목이지만, 그 끝 두 글자 "국어"가 우연히 표준 과목과
+ * 일치한다. 제일 먼저 나오는 지점만 보고 거기서 잘라버리면 "생활중"+"국어"로 잘못
+ * 쪼개진다. 그래서 가능한 절단 지점을 전부 후보로 놓고, 선택과목을 가장 길게(=가장
+ * 적게 쪼개는 쪽으로) 잡는 후보부터 시도해서 목표 개수(remainingCount)에 맞는 조합을
+ * 찾을 때까지 역추적한다.
+ */
+const segment = (text: string, start: number, remainingCount: number): string[] | null => {
+  if (remainingCount <= 0) return null;
+  if (start === text.length) return null;
+
+  const standardSubject = matchStandardSubjectAt(text, start);
+  if (standardSubject) {
+    if (start + standardSubject.length === text.length && remainingCount === 1) {
+      return [standardSubject];
+    }
+    const rest = segment(text, start + standardSubject.length, remainingCount - 1);
+    if (rest) return [standardSubject, ...rest];
+
+    // start 위치 자체가 표준 과목과 일치하는데도(예: "과학기술가정정보"의 "과학") 그
+    // 경로로 목표 개수를 못 맞췄다면, 이 위치를 선택과목의 시작으로 억지로 늘려 잡지
+    // 않는다. 그렇게 허용하면 "국어사회도덕수학과학기술가정정보"처럼 실제로는 표준
+    // 과목 여러 개가 이어진 열(예: 다른 열의 오탐)도 남는 글자를 몰아넣어 개수만
+    // 맞춰버려, 전혀 다른 열이 과목 열인 것처럼 잘못 통과된다.
+    return null;
+  }
+
+  const boundaries = findStandardSubjectStarts(text, start + 1);
+  boundaries.push(text.length);
+  const uniqueDescBoundaries = Array.from(new Set(boundaries)).sort((a, b) => b - a);
+
+  for (const boundary of uniqueDescBoundaries) {
+    const elective = text.slice(start, boundary);
+    if (!elective || elective.length > MAX_ELECTIVE_SUBJECT_LENGTH) continue;
+
+    if (boundary === text.length) {
+      if (remainingCount === 1) return [elective];
+      continue;
+    }
+
+    const rest = segment(text, boundary, remainingCount - 1);
+    if (rest) return [elective, ...rest];
+  }
+
+  return null;
+};
+
+/**
+ * @param subjectBlob 구분자 없이 붙어 있는 과목명 문자열
+ * @param expectedCount 같은 행의 원점수/성취도 셀을 줄바꿈으로 나눈 개수. 실제 과목 수의 근거다.
+ * @returns 분해된 과목명 목록. 개수가 안 맞으면(예: 선택과목 두 개가 구분자 없이 연달아 붙어
+ *          어디서 나눠야 할지 알 수 없는 경우) null이다.
+ */
+export const tokenizeSubjects = (subjectBlob: string, expectedCount: number): string[] | null => {
+  const normalized = stripDecorations(subjectBlob);
+  if (!normalized || expectedCount <= 0) return null;
+
+  return segment(normalized, 0, expectedCount);
+};

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -12,3 +12,7 @@ words:
   - mentee
   - toastify
   - daum
+  - tesseract
+  - pdfjs
+  - kordoc
+  - bbox

--- a/packages/api/src/hooks/oneseo/index.ts
+++ b/packages/api/src/hooks/oneseo/index.ts
@@ -14,6 +14,8 @@ export * from './usePostExcel';
 export * from './usePostImage';
 export * from './usePostMockScore';
 export * from './usePostMyOneseo';
+export * from './usePostSchoolRecordExtraction';
+export * from './usePostSchoolRecordOcr';
 export * from './usePutMyOneseo';
 export * from './usePostTempStorage';
 export * from './usePutOneseoById';

--- a/packages/api/src/hooks/oneseo/usePostSchoolRecordExtraction.ts
+++ b/packages/api/src/hooks/oneseo/usePostSchoolRecordExtraction.ts
@@ -1,0 +1,23 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import {
+  SchoolRecordExtractionRequestType,
+  SchoolRecordExtractionResponseType,
+} from '@repo/types';
+
+import { oneseoQueryKeys, oneseoUrl, post } from '../../libs';
+
+export const usePostSchoolRecordExtraction = (
+  options?: UseMutationOptions<
+    SchoolRecordExtractionResponseType,
+    AxiosError,
+    SchoolRecordExtractionRequestType
+  >,
+) =>
+  useMutation({
+    mutationKey: oneseoQueryKeys.postSchoolRecordExtraction(),
+    mutationFn: (data) =>
+      post<SchoolRecordExtractionResponseType>(oneseoUrl.postSchoolRecordExtraction(), data),
+    ...options,
+  });

--- a/packages/api/src/hooks/oneseo/usePostSchoolRecordOcr.ts
+++ b/packages/api/src/hooks/oneseo/usePostSchoolRecordOcr.ts
@@ -1,0 +1,17 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { SchoolRecordOcrResponseType } from '@repo/types';
+
+import { oneseoQueryKeys, oneseoUrl, post } from '../../libs';
+
+export const usePostSchoolRecordOcr = (
+  options?: UseMutationOptions<SchoolRecordOcrResponseType, AxiosError, FormData>,
+) =>
+  useMutation({
+    mutationKey: oneseoQueryKeys.postSchoolRecordOcr(),
+    // Content-Type을 직접 지정하지 않는다 — boundary 없이 명시하면 axios가 FormData를 보고
+    // boundary를 채워 넣는 걸 건너뛰어 서버가 멀티파트를 파싱하지 못할 수 있다.
+    mutationFn: (data) => post<SchoolRecordOcrResponseType>(oneseoUrl.postSchoolRecordOcr(), data),
+    ...options,
+  });

--- a/packages/api/src/libs/queryKeys.ts
+++ b/packages/api/src/libs/queryKeys.ts
@@ -11,6 +11,8 @@ export const oneseoQueryKeys = {
   postMockScore: (type: GraduationType) => ['mock', 'oneseo', 'score', type],
   putOneseoByMemberId: (memberId: number) => ['put', 'oneseo', memberId],
   postImage: () => ['post', 'certification', 'image'],
+  postSchoolRecordExtraction: () => ['post', 'school-record', 'extraction'],
+  postSchoolRecordOcr: () => ['post', 'school-record', 'ocr'],
   getSearchedOneseoList: (
     page: number,
     size: number,

--- a/packages/api/src/libs/requestUrlController.ts
+++ b/packages/api/src/libs/requestUrlController.ts
@@ -24,6 +24,9 @@ export const oneseoUrl = {
   postMyOneseo: () => '/oneseo/v3/oneseo/me',
   putMyOneseo: () => '/oneseo/v3/oneseo/me',
   postImage: () => '/oneseo/v3/image',
+  postSchoolRecordExtraction: () => '/oneseo/v3/extraction/middle-school-achievement',
+  /** Java 백엔드가 아니라 이 Next.js 앱 자신의 API Route(kordoc 직접 호출)로 간다 */
+  postSchoolRecordOcr: () => '/school-record-ocr',
   getOneseoByMemberId: (memberId: number) => `/oneseo/v3/oneseo/${memberId}`,
   putOneseoByMemberId: (memberId: number) => `/oneseo/v3/oneseo/${memberId}`,
   getSearchedOneseoList: (

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,6 +10,7 @@ export * from './modal';
 export * from './notion';
 export * from './oneseo';
 export * from './operation';
+export * from './schoolRecordExtraction';
 export * from './semester';
 export * from './step';
 export * from './value';

--- a/packages/types/src/schoolRecordExtraction.ts
+++ b/packages/types/src/schoolRecordExtraction.ts
@@ -1,0 +1,66 @@
+import { FreeSemesterValueEnum, GraduationTypeValueEnum, LiberalSystemValueEnum } from './value';
+
+export type SchoolRecordExtractionSourceType = 'TEXT_LAYER' | 'OCR';
+
+export interface SchoolRecordExtractionRequestType {
+  rawText: string;
+  pageCount?: number;
+  hasTextLayer?: boolean;
+  source: SchoolRecordExtractionSourceType;
+  recognitionConfidence?: number;
+  graduationType: GraduationTypeValueEnum.CANDIDATE | GraduationTypeValueEnum.GRADUATE;
+  liberalSystem?: LiberalSystemValueEnum;
+}
+
+/** OCR/텍스트 인식에 실패한 칸은 null로 내려온다 */
+export type NullableScoreArray = (number | null)[] | null;
+
+export interface SchoolRecordExtractionAchievementType {
+  achievement1_1: NullableScoreArray;
+  achievement1_2: NullableScoreArray;
+  achievement2_1: NullableScoreArray;
+  achievement2_2: NullableScoreArray;
+  achievement3_1: NullableScoreArray;
+  achievement3_2: NullableScoreArray;
+  generalSubjects: string[];
+  newSubjects: string[];
+  artsPhysicalSubjects: string[];
+  artsPhysicalAchievement: NullableScoreArray;
+  absentDays: NullableScoreArray;
+  attendanceDays: NullableScoreArray;
+  volunteerTime: NullableScoreArray;
+  liberalSystem: LiberalSystemValueEnum | null;
+  freeSemester: FreeSemesterValueEnum | null;
+}
+
+export interface SchoolRecordExtractionWarningType {
+  field: string;
+  index?: number;
+  rawText?: string;
+  type: string;
+  message: string;
+}
+
+export interface SchoolRecordExtractionMetaType {
+  confidence: number;
+  hasTextLayer: boolean;
+  source: SchoolRecordExtractionSourceType;
+  pageCount: number;
+  unrecognizedSubjects: string[];
+  missingSemesters: string[];
+  warnings: SchoolRecordExtractionWarningType[];
+}
+
+export interface SchoolRecordExtractionResponseType {
+  achievement: SchoolRecordExtractionAchievementType;
+  meta: SchoolRecordExtractionMetaType;
+}
+
+/** 생기부 PDF 전체를 Next.js API Route(kordoc)로 보내 인식한 결과 */
+export interface SchoolRecordOcrResponseType {
+  rawText: string;
+  unrecognizedSubjectBlobs: string[];
+  hasTextLayer: boolean;
+  source: SchoolRecordExtractionSourceType;
+  pageCount: number;
+}

--- a/packages/ui/src/components/SchoolRecordUploader/index.tsx
+++ b/packages/ui/src/components/SchoolRecordUploader/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { AxiosError } from 'axios';
 import { useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 
@@ -133,10 +134,15 @@ const SchoolRecordUploader = ({
       }
     } catch (error) {
       setStatus('error');
+      // axios가 던지는 에러는 error.message가 "Request failed with status code 422" 같은
+      // 고정 문구라, 백엔드가 응답 본문에 실어 보낸 실제 한국어 안내(예: "생기부를 인식하지
+      // 못했어요...")를 먼저 확인한다. axios가 아닌 에러(예: 아래 rawText 길이 체크에서
+      // 직접 throw한 Error)는 그 message를 그대로 쓴다.
+      const axiosError = error as AxiosError<{ message?: string }>;
       const message =
-        error instanceof Error
-          ? error.message
-          : '생기부를 인식하는 중 문제가 발생했어요. 다시 시도해 주세요.';
+        axiosError.response?.data?.message ??
+        (error instanceof Error ? error.message : undefined) ??
+        '생기부를 인식하는 중 문제가 발생했어요. 다시 시도해 주세요.';
       setErrorMessage(message);
       toast.error(message);
     }
@@ -210,12 +216,10 @@ const SchoolRecordUploader = ({
             'p-3',
           )}
         >
-          <p className={cn('text-xs', 'font-semibold', 'text-red-700')}>
-            자동 인식에 실패했어요
-          </p>
+          <p className={cn('text-xs', 'font-semibold', 'text-red-700')}>자동 인식에 실패했어요</p>
           <p className={cn('text-xs', 'text-slate-600')}>
-            스캔 이미지 형태의 PDF라 글자를 알아보기 어려웠어요. 성적·출결·봉사 항목을 직접
-            입력해 주세요.
+            스캔 이미지 형태의 PDF라 글자를 알아보기 어려웠어요. 성적·출결·봉사 항목을 직접 입력해
+            주세요.
           </p>
         </div>
       )}
@@ -226,8 +230,8 @@ const SchoolRecordUploader = ({
             생기부 내용을 초안으로 채웠어요
           </p>
           <p className={cn('text-xs', 'text-amber-700')}>
-            자동으로 채운 값이 정확하지 않을 수 있으니, 제출 전에 반드시 실제 생활기록부와
-            한 번씩 대조해서 확인해 주세요.
+            자동으로 채운 값이 정확하지 않을 수 있으니, 제출 전에 반드시 실제 생활기록부와 한 번씩
+            대조해서 확인해 주세요.
           </p>
         </div>
       )}

--- a/packages/ui/src/components/SchoolRecordUploader/index.tsx
+++ b/packages/ui/src/components/SchoolRecordUploader/index.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { toast } from 'react-toastify';
+
+import { usePostSchoolRecordExtraction, usePostSchoolRecordOcr } from '@repo/api/hooks';
+import {
+  GraduationTypeValueEnum,
+  LiberalSystemValueEnum,
+  SchoolRecordExtractionAchievementType,
+  SchoolRecordExtractionMetaType,
+} from '@repo/types';
+import { cn } from '@repo/utils';
+
+import { CloseIcon, InfoIcon } from '../../icons';
+import { Button } from '../../shadcn';
+
+const MAX_FILE_SIZE = 20 * 1024 * 1024;
+const MIN_RAW_TEXT_LENGTH = 200;
+/** 순수 스캔본(OCR 경로)인데 인식률이 이 미만이면 부분 성공이 아니라 인식 실패로 안내한다 */
+const OCR_FAILURE_CONFIDENCE_THRESHOLD = 0.3;
+
+type UploadStatus = 'idle' | 'processing' | 'submitting' | 'done' | 'error';
+
+interface SchoolRecordUploaderProps {
+  graduationType: GraduationTypeValueEnum.CANDIDATE | GraduationTypeValueEnum.GRADUATE;
+  liberalSystem: LiberalSystemValueEnum | null;
+  onApplyAchievement: (achievement: SchoolRecordExtractionAchievementType) => void;
+}
+
+const STATUS_TEXT: Partial<Record<UploadStatus, string>> = {
+  processing: '생기부를 인식하는 중이에요...',
+  submitting: '입력 내용을 채우는 중이에요...',
+};
+
+const toastOption = {
+  icon: InfoIcon,
+  closeButton: (
+    <button className={cn('cursor')} onClick={() => toast.dismiss()}>
+      <CloseIcon />
+    </button>
+  ),
+};
+
+const SchoolRecordUploader = ({
+  graduationType,
+  liberalSystem,
+  onApplyAchievement,
+}: SchoolRecordUploaderProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [status, setStatus] = useState<UploadStatus>('idle');
+  const [meta, setMeta] = useState<SchoolRecordExtractionMetaType | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [recognitionFailed, setRecognitionFailed] = useState(false);
+
+  const { mutateAsync: extractSchoolRecord } = usePostSchoolRecordExtraction();
+  const { mutateAsync: extractSchoolRecordOcr } = usePostSchoolRecordOcr();
+
+  const isProcessing = status === 'processing' || status === 'submitting';
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+
+    if (file.type !== 'application/pdf') {
+      toast.error('PDF 파일만 업로드할 수 있어요.');
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      toast.error('파일 용량은 20MB 이하만 업로드할 수 있어요.');
+      return;
+    }
+
+    setErrorMessage(null);
+    setMeta(null);
+    setRecognitionFailed(false);
+    setStatus('processing');
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file, file.name);
+      const extraction = await extractSchoolRecordOcr(formData);
+
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.debug(
+          `[OCR-DEBUG] rawText length=${extraction.rawText.length} pageCount=${extraction.pageCount} source=${extraction.source} hasTextLayer=${extraction.hasTextLayer} unrecognizedSubjectBlobs=${extraction.unrecognizedSubjectBlobs.length}`,
+        );
+      }
+
+      if (extraction.rawText.replace(/\s+/g, '').length < MIN_RAW_TEXT_LENGTH) {
+        throw new Error(
+          '생기부에서 성적·출결·봉사 내용을 충분히 인식하지 못했어요. 스캔 화질을 확인하거나 직접 입력해 주세요.',
+        );
+      }
+
+      setStatus('submitting');
+      const response = await extractSchoolRecord({
+        rawText: extraction.rawText,
+        pageCount: extraction.pageCount,
+        hasTextLayer: extraction.hasTextLayer,
+        source: extraction.source,
+        graduationType,
+        liberalSystem: liberalSystem ?? undefined,
+      });
+
+      onApplyAchievement(response.achievement);
+      setMeta(response.meta);
+      setStatus('done');
+
+      const failed =
+        response.meta.source === 'OCR' &&
+        response.meta.confidence < OCR_FAILURE_CONFIDENCE_THRESHOLD;
+      setRecognitionFailed(failed);
+
+      if (failed) {
+        toast.error(
+          '스캔 이미지라 자동 인식이 어려웠어요. 성적·출결·봉사 항목을 직접 입력해 주세요.',
+          toastOption,
+        );
+      } else if (response.meta.warnings.length > 0) {
+        toast.warn(
+          `생기부 내용을 초안으로 채웠어요. ${response.meta.warnings.length}개 항목은 직접 확인이 필요해요.`,
+          toastOption,
+        );
+      } else {
+        toast.success(
+          '생기부 내용을 자동으로 입력했어요. 값을 다시 한 번 확인해 주세요.',
+          toastOption,
+        );
+      }
+    } catch (error) {
+      setStatus('error');
+      const message =
+        error instanceof Error
+          ? error.message
+          : '생기부를 인식하는 중 문제가 발생했어요. 다시 시도해 주세요.';
+      setErrorMessage(message);
+      toast.error(message);
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'w-full',
+        'flex',
+        'flex-col',
+        'gap-3',
+        'rounded-lg',
+        'border',
+        'border-slate-200',
+        'bg-slate-50',
+        'p-4',
+        'mb-8',
+      )}
+    >
+      <div className={cn('flex', 'items-start', 'justify-between', 'gap-4')}>
+        <div className={cn('flex', 'items-center', 'gap-3')}>
+          <div className={cn('flex', 'flex-col', 'gap-1')}>
+            <p className={cn('text-sm', 'font-semibold', 'text-slate-900')}>
+              생활기록부 PDF로 자동 입력해 보세요
+            </p>
+            <p className={cn('text-xs', 'font-normal', 'text-slate-600', 'leading-5')}>
+              정부24에서 발급한 생기부 PDF를 올리면 성적·출결·봉사 항목을 초안으로 채워드려요.
+              <br />
+              인식하지 못한 항목은 직접 입력해야 해요.
+            </p>
+          </div>
+        </div>
+        <div className={cn('flex', 'flex-col', 'items-end', 'gap-1')}>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="application/pdf"
+            className={cn('hidden')}
+            onChange={handleFileChange}
+            disabled={isProcessing}
+          />
+          <Button
+            type="button"
+            variant="next"
+            size="sm"
+            disabled={isProcessing}
+            onClick={() => inputRef.current?.click()}
+          >
+            {isProcessing ? '처리 중...' : 'PDF 업로드'}
+          </Button>
+        </div>
+      </div>
+
+      {isProcessing && <p className={cn('text-xs', 'text-blue-700')}>{STATUS_TEXT[status]}</p>}
+
+      {status === 'error' && errorMessage && (
+        <p className={cn('text-xs', 'text-red-600')}>{errorMessage}</p>
+      )}
+
+      {status === 'done' && meta && recognitionFailed && (
+        <div
+          className={cn(
+            'flex',
+            'flex-col',
+            'gap-1',
+            'rounded-md',
+            'border',
+            'border-red-200',
+            'bg-white',
+            'p-3',
+          )}
+        >
+          <p className={cn('text-xs', 'font-semibold', 'text-red-700')}>
+            자동 인식에 실패했어요
+          </p>
+          <p className={cn('text-xs', 'text-slate-600')}>
+            스캔 이미지 형태의 PDF라 글자를 알아보기 어려웠어요. 성적·출결·봉사 항목을 직접
+            입력해 주세요.
+          </p>
+        </div>
+      )}
+
+      {status === 'done' && meta && !recognitionFailed && (
+        <div className={cn('flex', 'flex-col', 'gap-1', 'rounded-md', 'bg-white', 'p-3')}>
+          <p className={cn('text-xs', 'font-semibold', 'text-slate-900')}>
+            생기부 내용을 초안으로 채웠어요
+          </p>
+          <p className={cn('text-xs', 'text-amber-700')}>
+            자동으로 채운 값이 정확하지 않을 수 있으니, 제출 전에 반드시 실제 생활기록부와
+            한 번씩 대조해서 확인해 주세요.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SchoolRecordUploader;

--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -685,6 +685,7 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
             {step === StepEnum.FOUR && (
               <Step4Register
                 {...step4UseForm}
+                type={type}
                 graduationType={graduationType}
                 isGED={isGED}
                 isCandidate={isCandidate}

--- a/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
+++ b/packages/ui/src/components/form/ArtPhysicalForm/index.tsx
@@ -182,7 +182,9 @@ const ArtPhysicalForm = ({
                           'px-[0.5rem]',
                           'border-slate-300',
                           isGraduate ? 'w-[7.34rem]' : isFreeGrade ? 'w-[10.46rem]' : 'w-[5.47rem]',
-                          score === undefined && showError && '!border-red-600',
+                          (score === undefined || score === null) &&
+                            showError &&
+                            '!border-red-600',
                         ])}
                       >
                         <SelectValue placeholder="성적 선택" />

--- a/packages/ui/src/components/form/FreeGradeForm/index.tsx
+++ b/packages/ui/src/components/form/FreeGradeForm/index.tsx
@@ -22,6 +22,7 @@ const defaultSubjectLength = GENERAL_SUBJECTS.length;
 
 interface FreeGradeFormProps {
   subjectArray: string[];
+  subjectKeys: string[];
   control: Control<Step4FormType>;
   setValue: UseFormSetValue<Step4FormType>;
   register: UseFormRegister<Step4FormType>;
@@ -57,6 +58,7 @@ const rowStyle = [
 
 const FreeGradeForm = ({
   subjectArray,
+  subjectKeys,
   setValue,
   register,
   control,
@@ -123,7 +125,7 @@ const FreeGradeForm = ({
         const isNewSubjectError = newSubjectHasError && showError && '!border-red-600';
         return (
           <div
-            key={subject}
+            key={subjectKeys[idx] ?? idx}
             className={cn([
               ...rowStyle,
               'bg-white',
@@ -178,7 +180,7 @@ const FreeGradeForm = ({
 
                         setValue(field, next, { shouldDirty: true, shouldValidate: true });
                       }}
-                      defaultValue={Number.isInteger(score) ? String(score) : ''}
+                      value={Number.isInteger(score) ? String(score) : ''}
                     >
                       <SelectTrigger
                         className={cn(

--- a/packages/ui/src/components/form/FreeSemesterForm/index.tsx
+++ b/packages/ui/src/components/form/FreeSemesterForm/index.tsx
@@ -23,6 +23,7 @@ const defaultSubjectLength = GENERAL_SUBJECTS.length;
 
 interface FreeSemesterFormProps {
   subjectArray: string[];
+  subjectKeys: string[];
   setValue: UseFormSetValue<Step4FormType>;
   register: UseFormRegister<Step4FormType>;
   control: Control<Step4FormType>;
@@ -84,6 +85,7 @@ const freeSemesterToAchievementField: Record<FreeSemesterValueEnum, SemesterIdTy
 const FreeSemesterForm = ({
   register,
   subjectArray,
+  subjectKeys,
   setValue,
   control,
   handleDeleteSubjectClick,
@@ -207,7 +209,7 @@ const FreeSemesterForm = ({
         const isNewSubjectError = newSubjectHasError && showError && '!border-red-600';
         return (
           <div
-            key={subject}
+            key={subjectKeys[idx] ?? idx}
             className={cn([
               ...rowStyle,
               'bg-white',
@@ -282,7 +284,7 @@ const FreeSemesterForm = ({
 
                             setValue(field, next, { shouldDirty: true, shouldValidate: true });
                           }}
-                          defaultValue={Number.isInteger(score) ? String(score) : ''}
+                          value={Number.isInteger(score) ? String(score) : ''}
                         >
                           <SelectTrigger
                             className={cn(

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -13,6 +13,7 @@ export { default as LoginDialog } from './LoginDialog';
 export { default as LoginDialogContent } from './LoginDialogContent';
 export { default as ModalContainer } from './ModalContainer';
 export { default as RadioButton } from './RadioButton';
+export { default as SchoolRecordUploader } from './SchoolRecordUploader';
 export { default as SearchDialog } from './SearchDialog';
 export { default as SearchElements } from './SearchElements';
 export { default as StepBar } from './StepBar';

--- a/packages/ui/src/components/register/Step4Register/index.tsx
+++ b/packages/ui/src/components/register/Step4Register/index.tsx
@@ -1,4 +1,3 @@
- 
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
@@ -14,17 +13,18 @@ import {
   useWatch,
 } from 'react-hook-form';
 
-import { GENERAL_SUBJECTS } from '@repo/constants';
+import { ACHIEVEMENT_FIELD_LIST, GENERAL_SUBJECTS } from '@repo/constants';
 import {
   AchievementType,
   FreeSemesterValueEnum,
   GraduationTypeValueEnum,
   LiberalSystemValueEnum,
+  SchoolRecordExtractionAchievementType,
   Step4FormType,
 } from '@repo/types';
 import { cn } from '@repo/utils';
 
-import { FormController, LiberalSystemSwitch } from '../../';
+import { FormController, LiberalSystemSwitch, SchoolRecordUploader } from '../../';
 import { Input } from '../../../shadcn';
 import { ArtPhysicalForm, FreeGradeForm, FreeSemesterForm, NonSubjectForm } from '../../form';
 
@@ -146,6 +146,19 @@ const Step4Register = ({
   const [subjectArray, setSubjectArray] = useState<string[]>([...GENERAL_SUBJECTS]);
   const defaultSubjectLength = GENERAL_SUBJECTS.length;
 
+  // 행을 그릴 때 React key로 과목 "이름"(중복 가능)이나 배열 "위치"(삭제/재정렬 시 뒤 행이
+  // 앞으로 당겨오며 값이 안 바뀐 것처럼 보이는 input 재사용 버그)를 쓰면 둘 다 문제가
+  // 있었다. 그래서 각 행이 생성될 때 한 번 발급하고 그 행이 사라질 때까지 절대 안 바뀌는
+  // 고유 key를 별도로 관리한다 — react-hook-form의 useFieldArray가 내부적으로 하는 것과
+  // 같은 방식이다.
+  const subjectKeyCounterRef = useRef(0);
+  const nextSubjectKey = () => `subject-${(subjectKeyCounterRef.current += 1)}`;
+  // 렌더 중에는 ref를 읽거나 쓰면 안 되므로, 처음 9개(일반교과 고정 과목)는 ref 없이
+  // 정해진 이름으로 초기화한다 — 이후 추가되는 행만 nextSubjectKey()로 발급한다.
+  const [subjectKeys, setSubjectKeys] = useState<string[]>(() =>
+    GENERAL_SUBJECTS.map((_, index) => `general-${index}`),
+  );
+
   // 렌더 중 구독은 watch() 대신 useWatch 사용 (React Compiler 호환)
   const liberalSystem = useWatch({ control, name: 'liberalSystem' });
   const freeSemester = useWatch({ control, name: 'freeSemester' });
@@ -173,6 +186,7 @@ const Step4Register = ({
     unregister(`achievement3_1.${idx}`, undefined);
     unregister(`achievement3_2.${idx}`, undefined);
     setSubjectArray(filteredSubjects);
+    setSubjectKeys((prev) => prev.filter((_, i) => i !== idx));
 
     // 이벤트 핸들러에서는 구독이 불필요 — getValues() 사용 (React Compiler 호환)
     const newSubjects = getValues('newSubjects');
@@ -196,22 +210,99 @@ const Step4Register = ({
   };
 
   const handleAddSubjectClick = (subjectName?: string) => {
-    const newSubject = subjectName
-      ? subjectName
-      : `추가과목 ${subjectArray.length - defaultSubjectLength}`;
-    setSubjectArray((prev) => [...prev, newSubject]);
+    // subjectArray.length를 클로저에서 그대로 읽으면, 버튼을 연달아 눌러 리렌더가 아직
+    // 안 끝난 사이에 두 번째 클릭이 들어왔을 때 똑같은 길이를 두 번 읽어버린다 — 그러면
+    // "추가과목 N" 이름이 겹치는 것은 물론, achievement 배열에 값을 채워 넣는 인덱스도
+    // 겹쳐서 두 번째 클릭이 첫 번째 클릭의 자리를 덮어써 버린다. setSubjectArray의
+    // 함수형 업데이트 안에서 prev.length를 써야 매번 실제 최신 길이를 본다.
+    setSubjectArray((prev) => {
+      const newSubject = subjectName ? subjectName : `추가과목 ${prev.length - defaultSubjectLength}`;
+      const newIndex = prev.length;
 
-    if (getValues('liberalSystem') === LiberalSystemValueEnum.FREE_GRADE) {
-      achievementList.forEach(({ field }) =>
-        setValue(`${field}.${subjectArray.length}`, getValues(`${field}.${subjectArray.length}`)),
-      );
-    } else {
-      achievementList.forEach(
-        ({ field, value }) =>
-          value !== getValues('freeSemester') &&
-          setValue(`${field}.${subjectArray.length}`, getValues(`${field}.${subjectArray.length}`)),
-      );
+      if (getValues('liberalSystem') === LiberalSystemValueEnum.FREE_GRADE) {
+        achievementList.forEach(({ field }) =>
+          setValue(`${field}.${newIndex}`, getValues(`${field}.${newIndex}`)),
+        );
+      } else {
+        achievementList.forEach(
+          ({ field, value }) =>
+            value !== getValues('freeSemester') &&
+            setValue(`${field}.${newIndex}`, getValues(`${field}.${newIndex}`)),
+        );
+      }
+
+      return [...prev, newSubject];
+    });
+    setSubjectKeys((prev) => [...prev, nextSubjectKey()]);
+  };
+
+  /**
+   * 서버(MiddleSchoolRecordParser)가 내려주는 attendanceDays는 학년 단위로 묶여 있다
+   * (index = (학년-1)*3 + [지각,조퇴,결과]). 그런데 이 폼(NonSubjectForm)과 제출된
+   * 원서를 보여주는 ApplicationPrintPage/ExtracurricularTable은 항목 단위로 묶은
+   * 배열을 쓴다(지각 3칸이 [0,1,2], 조퇴가 [3,4,5], 결과가 [6,7,8]). 이 둘을 그대로
+   * 이어붙이면 학년2의 지각 자리에 학년1의 조퇴 값이 들어가는 식으로 값이 뒤섞인다.
+   * 그래서 서버 배열을 폼이 기대하는 순서로 재배열한다.
+   */
+  const reorderAttendanceDaysForForm = (
+    serverAttendanceDays: SchoolRecordExtractionAchievementType['attendanceDays'],
+  ): SchoolRecordExtractionAchievementType['attendanceDays'] => {
+    if (!serverAttendanceDays) return serverAttendanceDays;
+    const reordered: (number | null)[] = new Array(9).fill(null);
+    for (let grade = 1; grade <= 3; grade += 1) {
+      for (let typeOffset = 0; typeOffset < 3; typeOffset += 1) {
+        const serverIndex = (grade - 1) * 3 + typeOffset;
+        const formIndex = typeOffset * 3 + (grade - 1);
+        reordered[formIndex] = serverAttendanceDays[serverIndex] ?? null;
+      }
     }
+    return reordered;
+  };
+
+  const handleApplyOcrAchievement = (achievement: SchoolRecordExtractionAchievementType) => {
+    if (achievement.liberalSystem) {
+      setValue('liberalSystem', achievement.liberalSystem);
+    }
+    if (achievement.freeSemester) {
+      setValue('freeSemester', achievement.freeSemester);
+    }
+
+    // achievement1_1 등 성적 배열은 서버가 "이번 생기부에서 발견한 newSubjects 순서"를
+    // 기준으로 인덱스를 매겨 내려준다. 그런데 예전 코드는 기존에 추가돼 있던 과목 행을
+    // 지우지 않고 새 과목만 덧붙였다 — 그러면 화면의 행 순서(기존 과목 + 새 과목)와
+    // 서버가 준 배열의 순서(이번 newSubjects만)가 어긋나서, 예전에 추가했던 과목 행에
+    // 전혀 다른 과목의 점수가 잘못 표시되는 문제가 있었다(다른 생기부를 다시 OCR
+    // 적용했을 때 특히 눈에 띔). 그래서 추가 과목 행은 이번 OCR 결과로 완전히
+    // 교체한다.
+    const ocrNewSubjects = achievement.newSubjects || [];
+    const previousExtraCount = subjectArray.length - defaultSubjectLength;
+    for (let i = previousExtraCount - 1; i >= 0; i -= 1) {
+      unregister(`newSubjects.${i}`);
+    }
+    setSubjectArray([...GENERAL_SUBJECTS, ...ocrNewSubjects]);
+    setSubjectKeys((prev) => [
+      ...prev.slice(0, defaultSubjectLength),
+      ...ocrNewSubjects.map(() => nextSubjectKey()),
+    ]);
+    setValue('newSubjects', ocrNewSubjects);
+
+    // OCR이 인식하지 못한 칸은 null로 내려오는데, 기존 검증 로직이 null을 '입력 필요' 오류로
+    // 표시해 주므로 이 값을 그대로 반영하는 것만으로 검수 표시를 겸할 수 있다.
+    ACHIEVEMENT_FIELD_LIST.forEach((field) => {
+      setValue(field, (achievement[field] ?? null) as Step4FormType[typeof field]);
+    });
+    setValue(
+      'artsPhysicalAchievement',
+      (achievement.artsPhysicalAchievement ?? null) as Step4FormType['artsPhysicalAchievement'],
+    );
+    setValue('absentDays', achievement.absentDays as Step4FormType['absentDays']);
+    setValue(
+      'attendanceDays',
+      reorderAttendanceDaysForForm(achievement.attendanceDays) as Step4FormType['attendanceDays'],
+    );
+    setValue('volunteerTime', achievement.volunteerTime as Step4FormType['volunteerTime']);
+
+    trigger();
   };
 
   useEffect(() => {
@@ -328,134 +419,147 @@ const Step4Register = ({
             </div>
           </form>
         ) : (
-          <div
-            className={cn(
-              'flex',
-              'h-lvh',
-              'justify-center',
-              'bg-white',
-              'w-full',
-              'h-fit',
-              'gap-[2.5rem]',
-            )}
-          >
-            <FormController className={cn('mt-[5.625rem]')} />
-            <form
-              onSubmit={(e) => e.preventDefault()}
-              className={cn('flex', 'flex-col', 'items-center')}
-            >
-              <LiberalSystemSwitch
-                isFreeGrade={isFreeGrade}
-                isFreeSemester={isFreeSemester}
-                setValue={setValue}
-                className={cn('mb-[3rem]')}
+          <div className={cn('flex', 'flex-col', 'w-full')}>
+            {type === 'client' && (
+              <SchoolRecordUploader
+                graduationType={graduationType}
+                liberalSystem={liberalSystem ?? null}
+                onApplyAchievement={handleApplyOcrAchievement}
               />
-              <div
-                className={cn(
-                  'flex',
-                  'flex-col',
-                  'gap-[2.5rem]',
-                  'items-center',
-                  widthConvertor[`${liberalSystem}_${graduationType}`],
-                )}
+            )}
+            <div
+              className={cn(
+                'flex',
+                'h-lvh',
+                'justify-center',
+                'bg-white',
+                'w-full',
+                'h-fit',
+                'gap-[2.5rem]',
+              )}
+            >
+              <FormController className={cn('mt-[5.625rem]')} />
+              <form
+                onSubmit={(e) => e.preventDefault()}
+                className={cn('flex', 'flex-col', 'items-center')}
               >
-                <div className={cn([...formWrapper])}>
-                  <div className={cn('flex', 'justify-between', 'items-center')}>일반교과 성적</div>
-                  {isFreeGrade && (
-                    <FreeGradeForm
-                      achievementList={achievementList}
-                      register={register}
-                      setValue={setValue}
-                      subjectArray={subjectArray}
-                      control={control}
-                      errors={formState.errors}
-                      handleDeleteSubjectClick={handleDeleteSubjectClick}
-                      isGraduate={isGraduate}
-                      showError={showError}
-                      getValues={getValues}
-                      validateForm={validateForm}
-                    />
+                <LiberalSystemSwitch
+                  isFreeGrade={isFreeGrade}
+                  isFreeSemester={isFreeSemester}
+                  setValue={setValue}
+                  className={cn('mb-[3rem]')}
+                />
+                <div
+                  className={cn(
+                    'flex',
+                    'flex-col',
+                    'gap-[2.5rem]',
+                    'items-center',
+                    widthConvertor[`${liberalSystem}_${graduationType}`],
                   )}
-                  {isFreeSemester && (
-                    <FreeSemesterForm
-                      achievementList={achievementList}
-                      register={register}
-                      setValue={setValue}
-                      subjectArray={subjectArray}
-                      control={control}
-                      errors={formState.errors}
-                      handleDeleteSubjectClick={handleDeleteSubjectClick}
-                      freeSemester={freeSemester}
-                      isGraduate={isGraduate}
-                      showError={showError}
-                      getValues={getValues}
-                      validateForm={validateForm}
-                    />
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => handleAddSubjectClick()}
-                    className={cn(
-                      'text-sm',
-                      'font-semibold',
-                      'leading-6',
-                      'text-[#0F172A]',
-                      'h-[2.5rem]',
-                      'w-full',
-                      'flex',
-                      'items-center',
-                      'justify-center',
-                      'rounded-md',
-                      'border-[0.0625rem]',
-                      'border-slate-200',
+                >
+                  <div className={cn([...formWrapper])}>
+                    <div className={cn('flex', 'justify-between', 'items-center')}>
+                      일반교과 성적
+                    </div>
+                    {isFreeGrade && (
+                      <FreeGradeForm
+                        achievementList={achievementList}
+                        register={register}
+                        setValue={setValue}
+                        subjectArray={subjectArray}
+                        subjectKeys={subjectKeys}
+                        control={control}
+                        errors={formState.errors}
+                        handleDeleteSubjectClick={handleDeleteSubjectClick}
+                        isGraduate={isGraduate}
+                        showError={showError}
+                        getValues={getValues}
+                        validateForm={validateForm}
+                      />
                     )}
-                  >
-                    + 과목 추가하기
-                  </button>
-                </div>
-                <div id="artPhysicalSubject" className={cn([...formWrapper])}>
-                  예체능 교과 성적
-                  <ArtPhysicalForm
-                    graduationType={graduationType}
-                    setValue={setValue}
-                    control={control}
-                    isFreeGrade={isFreeGrade}
-                    isFreeSemester={isFreeSemester}
-                    isGraduate={isGraduate}
-                    showError={showError}
-                    freeSemester={freeSemester}
-                  />
-                </div>
-                <div id="nonSubject" className={cn([...formWrapper])}>
-                  <div className={cn('w-full', 'flex', 'justify-between')}>
-                    비교과 내용
-                    <div
+                    {isFreeSemester && (
+                      <FreeSemesterForm
+                        achievementList={achievementList}
+                        register={register}
+                        setValue={setValue}
+                        subjectArray={subjectArray}
+                        subjectKeys={subjectKeys}
+                        control={control}
+                        errors={formState.errors}
+                        handleDeleteSubjectClick={handleDeleteSubjectClick}
+                        freeSemester={freeSemester}
+                        isGraduate={isGraduate}
+                        showError={showError}
+                        getValues={getValues}
+                        validateForm={validateForm}
+                      />
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => handleAddSubjectClick()}
                       className={cn(
+                        'text-sm',
+                        'font-semibold',
+                        'leading-6',
+                        'text-[#0F172A]',
+                        'h-[2.5rem]',
+                        'w-full',
                         'flex',
                         'items-center',
                         'justify-center',
-                        'gap-1',
-                        'text-red-600',
-                        'text-[0.75rem]/[1.25rem]',
-                        'font-semibold',
+                        'rounded-md',
+                        'border-[0.0625rem]',
+                        'border-slate-200',
                       )}
                     >
-                      <p>*</p>
-                      <p>9월 30일까지의 미인정 결석·지각·조퇴·결과 및 봉사시간 입력</p>
-                    </div>
+                      + 과목 추가하기
+                    </button>
                   </div>
-                  <NonSubjectForm
-                    register={register}
-                    trigger={trigger}
-                    errors={formState.errors}
-                    isFreeGrade={isFreeGrade}
-                    isGraduate={isGraduate}
-                    showError={showError}
-                    validateForm={validateForm}
-                  />
+                  <div id="artPhysicalSubject" className={cn([...formWrapper])}>
+                    예체능 교과 성적
+                    <ArtPhysicalForm
+                      graduationType={graduationType}
+                      setValue={setValue}
+                      control={control}
+                      isFreeGrade={isFreeGrade}
+                      isFreeSemester={isFreeSemester}
+                      isGraduate={isGraduate}
+                      showError={showError}
+                      freeSemester={freeSemester}
+                    />
+                  </div>
+                  <div id="nonSubject" className={cn([...formWrapper])}>
+                    <div className={cn('w-full', 'flex', 'justify-between')}>
+                      비교과 내용
+                      <div
+                        className={cn(
+                          'flex',
+                          'items-center',
+                          'justify-center',
+                          'gap-1',
+                          'text-red-600',
+                          'text-[0.75rem]/[1.25rem]',
+                          'font-semibold',
+                        )}
+                      >
+                        <p>*</p>
+                        <p>9월 30일까지의 미인정 결석·지각·조퇴·결과 및 봉사시간 입력</p>
+                      </div>
+                    </div>
+                    <NonSubjectForm
+                      register={register}
+                      trigger={trigger}
+                      errors={formState.errors}
+                      isFreeGrade={isFreeGrade}
+                      isGraduate={isGraduate}
+                      showError={showError}
+                      validateForm={validateForm}
+                    />
+                  </div>
                 </div>
-              </div>
-            </form>
+              </form>
+            </div>
           </div>
         )}
       </div>

--- a/packages/ui/src/components/register/Step4Register/index.tsx
+++ b/packages/ui/src/components/register/Step4Register/index.tsx
@@ -216,7 +216,9 @@ const Step4Register = ({
     // 겹쳐서 두 번째 클릭이 첫 번째 클릭의 자리를 덮어써 버린다. setSubjectArray의
     // 함수형 업데이트 안에서 prev.length를 써야 매번 실제 최신 길이를 본다.
     setSubjectArray((prev) => {
-      const newSubject = subjectName ? subjectName : `추가과목 ${prev.length - defaultSubjectLength}`;
+      const newSubject = subjectName
+        ? subjectName
+        : `추가과목 ${prev.length - defaultSubjectLength}`;
       const newIndex = prev.length;
 
       if (getValues('liberalSystem') === LiberalSystemValueEnum.FREE_GRADE) {
@@ -262,6 +264,16 @@ const Step4Register = ({
   const handleApplyOcrAchievement = (achievement: SchoolRecordExtractionAchievementType) => {
     if (achievement.liberalSystem) {
       setValue('liberalSystem', achievement.liberalSystem);
+      // 아래 "전형(자유학기제/자유학년제) 변경 시 예체능 성적 초기화" effect는 사용자가
+      // LiberalSystemSwitch를 직접 눌러 모드를 바꿨을 때 이전 모드의 값을 지우기 위한
+      // 것이다. 그런데 OCR이 liberalSystem을 바꾸는 경우엔 artsPhysicalAchievement도
+      // 이미 새 모드에 맞게 같이 내려오는데, 다음 렌더에서 그 effect가 "모드가 바뀌었다"고
+      // 보고 이 값을 다시 null로 덮어써 자동 입력값이 사라지는 문제가 있었다. ref를
+      // 새 모드 기준으로 미리 맞춰 두면 그 effect가 "모드가 안 바뀌었다"고 보고 초기화를
+      // 건너뛴다 — 실제 사용자 조작으로 인한 모드 변경만 초기화 대상이 된다.
+      prevIsFreeSemesterRef.current =
+        achievement.liberalSystem === LiberalSystemValueEnum.FREE_SEMESTER;
+      prevIsFreeGradeRef.current = achievement.liberalSystem === LiberalSystemValueEnum.FREE_GRADE;
     }
     if (achievement.freeSemester) {
       setValue('freeSemester', achievement.freeSemester);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,13 +135,16 @@ importers:
         version: link:../../packages/utils
       '@sentry/nextjs':
         specifier: ^10.69.0
-        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.109.2(postcss@8.5.6))
+        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.109.2(postcss@8.5.6))
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.7)
       axios:
         specifier: ^1.13.5
         version: 1.13.5
+      kordoc:
+        specifier: ^4.9.1
+        version: 4.9.1(@types/node@20.19.33)
       next:
         specifier: ^16.2.10
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -924,6 +927,9 @@ packages:
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
 
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
@@ -994,6 +1000,16 @@ packages:
     peerDependencies:
       react-hook-form: ^7.55.0
 
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1014,6 +1030,9 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@hyzyla/pdfium@2.1.13':
+    resolution: {integrity: sha512-4J+xMFJW6V+jktxor6Lsk/2YdPCpeY+Ga69J98uyNQwYESkAsUDxz8BeFU0ZbZJIJ+fK3J6bm61gmwWnUzVU1g==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1024,14 +1043,36 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.34.5':
     resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1040,8 +1081,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1052,8 +1104,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -1064,8 +1128,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -1076,14 +1152,32 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1095,9 +1189,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -1109,9 +1217,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -1123,9 +1245,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1137,9 +1273,23 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1149,9 +1299,24 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
@@ -1161,9 +1326,21 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -1231,9 +1408,94 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1383,6 +1645,33 @@ packages:
     resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
@@ -2270,6 +2559,10 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
+    engines: {node: '>=14.6'}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -2289,6 +2582,14 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
+  adm-zip@0.5.18:
+    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
+    engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -2445,6 +2746,10 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -2494,6 +2799,10 @@ packages:
 
   caniuse-lite@1.0.30001774:
     resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2558,6 +2867,10 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
@@ -2602,6 +2915,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -2614,6 +2930,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2741,6 +3062,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -2799,6 +3123,10 @@ packages:
     resolution: {integrity: sha512-GVoi+ICHocoOIU7qVVM48wOJziRsqrsyqlI0Ce0LdowRn6v3bcH2zUa9kp85ncx0nwIb9/HOCOLS3fdThDG/XQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -2844,6 +3172,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -3096,6 +3427,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
@@ -3224,6 +3558,14 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
+  global-agent@4.1.3:
+    resolution: {integrity: sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g==}
+    engines: {node: '>=10.0'}
+
   global-directory@5.0.0:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
     engines: {node: '>=20'}
@@ -3250,6 +3592,9 @@ packages:
   graphql@16.13.0:
     resolution: {integrity: sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3322,6 +3667,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -3538,6 +3886,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -3593,6 +3944,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -3609,6 +3963,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3620,9 +3977,22 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  kordoc@4.9.1:
+    resolution: {integrity: sha512-kGwqIZNu6JAoOmseQqTcKeozuWBdJa5aZUxjfHbuFfSStBOGMuK1Ochb8VqCOhxabMmNZ1tJlkjVeltoWaDVTQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      puppeteer-core: '>=22.0.0'
+    peerDependenciesMeta:
+      puppeteer-core:
+        optional: true
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -3630,6 +4000,9 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -3641,6 +4014,9 @@ packages:
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -3661,9 +4037,24 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
+
+  matcher@4.0.0:
+    resolution: {integrity: sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==}
+    engines: {node: '>=10'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -3928,6 +4319,26 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
+  onnxruntime-common@1.27.0:
+    resolution: {integrity: sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow==}
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-node@1.27.0:
+    resolution: {integrity: sha512-QEzGwrvNBgv4uPVdnbHsOGG4G6T96mdlcFI8aAKPjMU8wOPpVocPXb6k3QGkaZagVTv2G9Bnnbo6Z3JdXr1fQw==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
+
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -3957,6 +4368,9 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4002,6 +4416,10 @@ packages:
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
+  pdfjs-dist@4.10.38:
+    resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
+    engines: {node: '>=20'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4028,6 +4446,9 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
@@ -4170,6 +4591,9 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -4181,12 +4605,20 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4269,6 +4701,9 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -4329,6 +4764,10 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
   rollup@4.62.3:
     resolution: {integrity: sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -4348,6 +4787,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -4370,6 +4812,9 @@ packages:
   semifies@1.0.0:
     resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4379,9 +4824,22 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+
+  serialize-error@8.1.0:
+    resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
+    engines: {node: '>=10'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -4399,6 +4857,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -4409,6 +4870,15 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4459,6 +4929,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -4507,6 +4980,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -4696,6 +5172,14 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
@@ -4735,6 +5219,9 @@ packages:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -5415,6 +5902,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
@@ -5497,6 +5989,21 @@ snapshots:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.71.2(react@19.2.7)
 
+  '@huggingface/jinja@0.5.9':
+    optional: true
+
+  '@huggingface/tokenizers@0.1.3':
+    optional: true
+
+  '@huggingface/transformers@4.2.0':
+    dependencies:
+      '@huggingface/jinja': 0.5.9
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+    optional: true
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5513,6 +6020,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@hyzyla/pdfium@2.1.13':
+    optional: true
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -5521,39 +6031,84 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
   '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -5561,9 +6116,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -5571,9 +6136,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -5581,9 +6156,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -5591,9 +6176,19 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -5601,13 +6196,32 @@ snapshots:
       '@emnapi/runtime': 1.8.1
     optional: true
 
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
   '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
   '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@inquirer/ansi@1.0.2': {}
@@ -5684,6 +6298,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.2)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.2
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@mswjs/interceptors@0.41.3':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -5692,6 +6328,54 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -5809,6 +6493,35 @@ snapshots:
   '@playwright/test@1.61.1':
     dependencies:
       playwright: 1.61.1
+
+  '@protobufjs/aspromise@1.1.2':
+    optional: true
+
+  '@protobufjs/base64@1.1.2':
+    optional: true
+
+  '@protobufjs/codegen@2.0.5':
+    optional: true
+
+  '@protobufjs/eventemitter@1.1.1':
+    optional: true
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+    optional: true
+
+  '@protobufjs/float@1.0.2':
+    optional: true
+
+  '@protobufjs/path@1.1.2':
+    optional: true
+
+  '@protobufjs/pool@1.1.0':
+    optional: true
+
+  '@protobufjs/utf8@1.1.2':
+    optional: true
 
   '@radix-ui/number@1.1.2': {}
 
@@ -6284,7 +6997,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.69.0
 
-  '@sentry/nextjs@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.109.2(postcss@8.5.6))':
+  '@sentry/nextjs@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.109.2(postcss@8.5.6))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.3)
@@ -6661,6 +7374,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@xmldom/xmldom@0.9.12': {}
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -6675,6 +7390,11 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  adler-32@1.3.1: {}
+
+  adm-zip@0.5.18:
+    optional: true
 
   agent-base@6.0.2:
     dependencies:
@@ -6862,6 +7582,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolean@3.2.0:
+    optional: true
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -6913,6 +7636,11 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001774: {}
+
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
 
   chalk@4.1.2:
     dependencies:
@@ -6973,6 +7701,8 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@13.1.0: {}
+
   commander@14.0.3: {}
 
   commander@2.20.3: {}
@@ -7000,6 +7730,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -7013,6 +7745,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.2
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7148,6 +7882,9 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  detect-node@2.1.0:
+    optional: true
+
   didyoumean@1.2.2: {}
 
   diff@8.0.3: {}
@@ -7193,6 +7930,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@4.5.0: {}
 
   env-paths@2.2.1: {}
 
@@ -7306,6 +8045,9 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es6-error@4.1.1:
+    optional: true
 
   escalade@3.2.0: {}
 
@@ -7657,6 +8399,9 @@ snapshots:
       flatted: 3.3.3
       keyv: 4.5.4
 
+  flatbuffers@25.9.23:
+    optional: true
+
   flatted@3.3.3: {}
 
   follow-redirects@1.15.11: {}
@@ -7775,6 +8520,24 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.4
+      serialize-error: 7.0.1
+    optional: true
+
+  global-agent@4.1.3:
+    dependencies:
+      globalthis: 1.0.4
+      matcher: 4.0.0
+      semver: 7.7.4
+      serialize-error: 8.1.0
+    optional: true
+
   global-directory@5.0.0:
     dependencies:
       ini: 6.0.0
@@ -7793,6 +8556,9 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphql@16.13.0: {}
+
+  guid-typescript@1.0.9:
+    optional: true
 
   has-bigints@1.1.0: {}
 
@@ -7859,6 +8625,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immediate@3.0.6: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -8049,6 +8817,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -8094,6 +8864,9 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-safe@5.0.1:
+    optional: true
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -8113,6 +8886,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -8121,14 +8901,42 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  kordoc@4.9.1(@types/node@20.19.33):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(zod@3.25.76)
+      '@xmldom/xmldom': 0.9.12
+      cfb: 1.2.2
+      commander: 13.1.0
+      jszip: 3.10.1
+      markdown-it: 14.3.0
+      zod: 3.25.76
+    optionalDependencies:
+      '@huggingface/transformers': 4.2.0
+      '@hyzyla/pdfium': 2.1.13
+      onnxruntime-node: 1.27.0
+      pdfjs-dist: 4.10.38
+      sharp: 0.35.3(@types/node@20.19.33)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@types/node'
+      - supports-color
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
 
   locate-path@6.0.0:
     dependencies:
@@ -8140,6 +8948,9 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
+
+  long@5.3.2:
+    optional: true
 
   loose-envify@1.4.0:
     dependencies:
@@ -8159,7 +8970,28 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+    optional: true
+
+  matcher@4.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+    optional: true
+
   math-intrinsics@1.1.0: {}
+
+  mdurl@2.1.0: {}
 
   media-typer@1.1.0: {}
 
@@ -8386,6 +9218,39 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    optional: true
+
+  onnxruntime-common@1.24.3:
+    optional: true
+
+  onnxruntime-common@1.27.0:
+    optional: true
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.18
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+    optional: true
+
+  onnxruntime-node@1.27.0:
+    dependencies:
+      adm-zip: 0.5.18
+      global-agent: 4.1.3
+      onnxruntime-common: 1.27.0
+    optional: true
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.6.5
+    optional: true
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -8434,6 +9299,8 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -8468,6 +9335,11 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
+  pdfjs-dist@4.10.38:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
+    optional: true
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -8481,6 +9353,9 @@ snapshots:
   pirates@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
+
+  platform@1.3.6:
+    optional: true
 
   playwright-core@1.61.1: {}
 
@@ -8555,6 +9430,8 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  process-nextick-args@2.0.1: {}
+
   progress@2.0.3: {}
 
   prompts@2.4.2:
@@ -8568,12 +9445,29 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 20.19.33
+      long: 5.3.2
+    optional: true
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -8645,6 +9539,16 @@ snapshots:
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -8719,6 +9623,16 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+    optional: true
+
   rollup@4.62.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -8774,6 +9688,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -8798,9 +9714,15 @@ snapshots:
 
   semifies@1.0.0: {}
 
+  semver-compare@1.0.0:
+    optional: true
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.5:
+    optional: true
 
   send@1.2.1:
     dependencies:
@@ -8817,6 +9739,16 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+    optional: true
+
+  serialize-error@8.1.0:
+    dependencies:
+      type-fest: 0.20.2
+    optional: true
 
   serve-static@2.2.1:
     dependencies:
@@ -8848,6 +9780,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -8927,6 +9861,40 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  sharp@0.35.3(@types/node@20.19.33):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 20.19.33
+    optional: true
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -8977,6 +9945,9 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  sprintf-js@1.1.3:
+    optional: true
 
   stable-hash@0.0.5: {}
 
@@ -9050,6 +10021,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   stringify-object@5.0.0:
     dependencies:
@@ -9241,6 +10216,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@0.13.1:
+    optional: true
+
+  type-fest@0.20.2:
+    optional: true
+
   type-fest@0.7.1: {}
 
   type-fest@5.4.4:
@@ -9298,6 +10279,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.2: {}
+
+  uc.micro@2.1.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
## 개요 💡

정부24 생기부 PDF를 업로드하면 성적·출결·봉사 항목을 자동으로 채워주는 기능을 추가합니다.

기존에는 서버(Java)가 OCR(kordoc)을 CLI 서브프로세스로 직접 실행해서 JVM과 메모리를 다투다 502가 나던 문제가 있었습니다. 
OCR 추출을 **Next.js API 라우트**로 옮기고, 서버는 완성된 텍스트를 파싱만 하도록 역할을 분리했습니다. 
서버의 `MiddleSchoolRecordParser`는 그대로 재사용하고, kordoc의 표 재구성 결과를 그 파서가 기대하는 줄 형식으로 되돌리는 변환 계층을 새로 만들었습니다.

실제 정부24 PDF 4건으로 반복 업로드하며 서버 응답(인식률·경고)을 직접 확인해 아래 문제들을 찾아 고쳤습니다.

## 작업내용 ⌨️

**kordoc 추출 파이프라인 (850838ed)**

- `apps/client/src/app/api/school-record-ocr/route.ts`: PDF → kordoc → rawText 추출 라우트
- `achievementTextConverter.ts` — 실 데이터 검증 중 발견한 버그
  - 병합 셀 때문에 학기 칸이 `"1"`이 아니라 `"111"`, `"11111111222"`처럼 나오던 문제 → 다수결 판정 + 초과분 다음 행 이월
  - 서로 다른 데이터가 한 표에 섞였을 때 학기 값이 다음 데이터로 새어 들어가던 문제 → 안전하게 확정된 경우에만 추론
  - "교과"(분류명) 열과 "과목"(실제 과목) 열을 혼동해 "예술"이 "음악"/"미술" 대신 잘못 인식되던 문제
  - "원점수"와 "성취도" 열이 분리돼 있는데 성취도만 쓰고 원점수를 버리던 문제
  - 예체능·선택과목 표가 `[N학년]` 헤딩보다 배열상 늦게 나와 앞 학년 데이터가 다음 학년 것으로 잘못 찍히던 문제 → 페이지 위치정보(bbox)로 고치려 했으나 스캔 PDF엔 그 정보 자체가 없어서, 대신 "일반교과 표 학년 배정은 항상 맞다"는 점에 착안해 예체능/선택과목은 직전 일반교과 행의 학년을 따라가도록 변경
  - 출결 표가 다른 표와 같은 방식으로 처리되어 서버 파서의 고정 포맷과 안 맞아 인식 실패하던 문제 → 전용 포맷터 추가
  - 인적사항 등 민감 섹션이 표 인식 실패 시 그대로 새어나갈 수 있는 위험 → 섹션 상태 추적으로 차단
  - 디버그 로그에 생기부 원문이 그대로 찍히던 것 → `NODE_ENV !== 'production'`에서만 출력
- `subjectTokenizer.ts`: 구분자 없는 과목명 문자열 분해 로직. "생활중국어"가 "생활중"+"국어"로 잘못 쪼개지던 문제, 사전에 없는 열도 아무 문자열이나 통과시키던 문제를 백트래킹 + 길이 상한으로 방지

**API 훅/타입 (1823d838)**

- `usePostSchoolRecordOcr` / `usePostSchoolRecordExtraction` 훅과 관련 타입 추가

**UI 연동 (d4365c40)**

- `SchoolRecordUploader` 추가, 항목별 경고 대신 "실제 생기부와 대조해달라"는 안내로 단순화
- OCR 재적용 시 이전 추가 과목이 안 지워져 값이 밀리던 문제
- 서버 출결 배열(학년 단위)과 폼이 기대하는 배열(항목 단위)이 달라 값이 뒤섞이던 문제
- 과목 추가/삭제 행의 React key가 불안정해 삭제가 반영 안 되던 문제

## 스크린샷/동영상 📸


https://github.com/user-attachments/assets/328f555a-31af-4191-af9e-a080044ee46c



## 관련 이슈 🚨

closes #450

## 리뷰 요청사항 👀

- `achievementTextConverter.ts`의 휴리스틱들이 검증한 PDF 4건에 과도하게 맞춰진 건 아닌지 확인 부탁드립니다.
- 사전에 없는 두 선택과목이 붙어 나오면 여전히 "직접 확인 필요"로 넘깁니다 — 추측 채움보다 안전하다고 판단했는데 의견 부탁드려요.