### PR TITLE
[fix] 원서 작성 요령 다운로드 링크 새 탭 열기 수정

### DIFF
--- a/apps/client/src/pageContainer/GuidePage/index.tsx
+++ b/apps/client/src/pageContainer/GuidePage/index.tsx
@@ -69,6 +69,8 @@ const Elements: ElementType[] = [
         <a
           className={cn('flex', 'items-center', 'gap-3', 'mt-5', 'cursor-pointer', 'w-fit')}
           href={`${process.env.NEXT_PUBLIC_CDN_URL}/입학_원서_작성_요령.hwp`}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           <CopyIcon color="#94A3B8" />
           <span


### PR DESCRIPTION
## 개요 💡

원서 접수 안내 페이지에서 `입학 원서 작성 요령` `hwp` 파일 다운로드 링크를 클릭해도 다운로드가 되지 않는 문제를 수정하였습니다.

## 작업내용 ⌨️

- `GuidePage`의 다운로드 링크(`<a>` 태그)에 `target="_blank"`, `rel="noopener noreferrer"`를 추가하여 새 탭에서 열리도록 수정하였습니다.

## 관련 이슈 🚨

Closes #449

## 리뷰 요청사항 👀

로컬에서 확인해보니 링크가 가리키는 `CloudFront` CDN의 `입학_원서_작성_요령.hwp` 파일 자체가 `403 Access Denied`를 반환하고 있습니다. 이는 프론트엔드 코드 문제가 아니라 `S3`/`CloudFront` 쪽 파일 부재 또는 버킷 권한 설정 문제로 보입니다. 이번 PR로 새 탭 열기 동작은 정상화되지만, CDN 쪽 파일 접근 권한이 해결되지 않으면 사용자는 여전히 다운로드에 실패할 수 있습니다. 별도로 인프라/CDN 담당자 확인이 필요합니다.
