### PR TITLE
[oneseo] 생기부 OCR 업로드 용량 제한 30MB로 상향

### DIFF
--- a/apps/client/src/app/api/school-record-ocr/route.ts
+++ b/apps/client/src/app/api/school-record-ocr/route.ts
@@ -9,7 +9,7 @@ import { convertKordocBlocks } from '@/lib/kordoc/achievementTextConverter';
 // kordoc은 Node 전용 라이브러리(파일 시스템, sharp 네이티브 모듈 등)라 Edge 런타임에서 못 돈다.
 export const runtime = 'nodejs';
 
-const MAX_FILE_SIZE = 20 * 1024 * 1024;
+const MAX_FILE_SIZE = 30 * 1024 * 1024;
 
 // axiosInstance의 응답 인터셉터가 백엔드(Java) 응답 형식({code, data, message, status})을
 // 가정하고 response.data.data를 꺼내 쓴다. 이 라우트도 같은 형식으로 감싸야 클라이언트의
@@ -18,7 +18,7 @@ const errorResponse = (message: string, status: number) =>
   NextResponse.json({ code: status, message, status: `${status}` }, { status });
 
 /**
- * 이 라우트는 인증·요청 제한 없이 그대로 두면 로그인 없이도 누구나 20MB짜리 OCR을 돌릴 수 있어
+ * 이 라우트는 인증·요청 제한 없이 그대로 두면 로그인 없이도 누구나 30MB짜리 OCR을 돌릴 수 있어
  * 리소스 남용에 노출된다(리뷰 지적). kordoc을 실행하기 전에 로그인 페이지들이 쓰는 것과 같은
  * SESSION 쿠키를 백엔드 인증 확인 엔드포인트로 검증해 비로그인 요청을 걷어낸다. 요청 빈도
  * 제한(rate limit)은 이 라우트 코드가 아니라 인프라(Vercel/백엔드) 쪽에서 적용하기로 했다.
@@ -62,7 +62,7 @@ export async function POST(request: NextRequest) {
   }
 
   if (file.size > MAX_FILE_SIZE) {
-    return errorResponse('파일 용량은 20MB 이하만 지원합니다.', 400);
+    return errorResponse('파일 용량은 30MB 이하만 지원합니다.', 400);
   }
 
   const buffer = Buffer.from(await file.arrayBuffer());

--- a/apps/client/src/app/api/school-record-ocr/route.ts
+++ b/apps/client/src/app/api/school-record-ocr/route.ts
@@ -10,6 +10,12 @@ import { convertKordocBlocks } from '@/lib/kordoc/achievementTextConverter';
 // kordoc은 Node 전용 라이브러리(파일 시스템, sharp 네이티브 모듈 등)라 Edge 런타임에서 못 돈다.
 export const runtime = 'nodejs';
 
+// 30MB 스캔 PDF는 kordoc OCR에 시간이 걸릴 수 있어 Vercel 기본 실행 시간 제한(플랜에 따라
+// 10~15초)을 넘길 위험이 있다(리뷰 지적). Hobby/Pro 플랜에서 별도 설정 없이 쓸 수 있는
+// 상한인 60초로 늘려 안전 마진을 확보한다. 실제 대용량 스캔 PDF로 처리 시간·메모리 사용량을
+// 재검증해 필요하면 더 조정해야 한다.
+export const maxDuration = 60;
+
 const MAX_FILE_SIZE = 30 * 1024 * 1024;
 
 // 파일은 브라우저에서 S3로 직접 PUT 업로드되고 이 라우트는 objectKey만 받는다 — Vercel

--- a/packages/ui/src/components/SchoolRecordUploader/index.tsx
+++ b/packages/ui/src/components/SchoolRecordUploader/index.tsx
@@ -16,7 +16,7 @@ import { cn } from '@repo/utils';
 import { CloseIcon, InfoIcon } from '../../icons';
 import { Button } from '../../shadcn';
 
-const MAX_FILE_SIZE = 20 * 1024 * 1024;
+const MAX_FILE_SIZE = 30 * 1024 * 1024;
 const MIN_RAW_TEXT_LENGTH = 200;
 /** 순수 스캔본(OCR 경로)인데 인식률이 이 미만이면 부분 성공이 아니라 인식 실패로 안내한다 */
 const OCR_FAILURE_CONFIDENCE_THRESHOLD = 0.3;
@@ -70,7 +70,7 @@ const SchoolRecordUploader = ({
     }
 
     if (file.size > MAX_FILE_SIZE) {
-      toast.error('파일 용량은 20MB 이하만 업로드할 수 있어요.');
+      toast.error('파일 용량은 30MB 이하만 업로드할 수 있어요.');
       return;
     }
 


### PR DESCRIPTION
## 개요 💡

정부24 생기부 PDF 업로드 시 개발 환경에서 `413` 오류가 발생하는 문제를 조사하였습니다. 클라이언트와 서버(`route.ts`)가 동일하게 `MAX_FILE_SIZE`를 `20MB`로 제한하고 있었고, 실제 정부24 발급 PDF는 스캔 페이지 포함 시 이 값을 초과하는 경우가 있어 문제가 재현되었습니다.

## 작업내용 ⌨️

- `apps/client/src/app/api/school-record-ocr/route.ts`의 `MAX_FILE_SIZE`를 `20MB`에서 `30MB`로 상향하고, 관련 주석·에러 메시지를 동일하게 수정하였습니다.
- `packages/ui/src/components/SchoolRecordUploader/index.tsx`의 클라이언트 측 `MAX_FILE_SIZE` 및 안내 토스트 메시지도 동일하게 `30MB`로 맞추었습니다.

## 관련 이슈 🚨

- 배포 플랫폼(Vercel)의 서버리스 함수 요청 본문 크기 제한(Fluid Compute 미적용 시 `4.5MB`, 적용 시 `100MB`)과는 별개의 애플리케이션 레벨 제한값 조정입니다. 배포 환경에서 재현 테스트가 필요하며, 동일 파일로도 `413`이 계속되면 Vercel 프로젝트의 Fluid Compute 활성화 여부 확인이 추가로 필요합니다.

## 리뷰 요청사항 👀

- `30MB`라는 상향 값이 리소스 남용 방지 관점에서 적절한지 확인 부탁드립니다.
