### PR TITLE
[schedule] 합격자 등록 시작 시간 추가

### DIFF
--- a/packages/constants/src/date.ts
+++ b/packages/constants/src/date.ts
@@ -63,10 +63,10 @@ export const ADMISSION_SCHEDULE = {
   registration: {
     /** 모집절차 스텝 표기 (client Section2) — 시작/종료/비고 분리 노출 */
     stepStart: '2026. 11. 4.(수) ~',
-    stepEnd: '11. 9.(월) 17:00',
+    stepEnd: '11. 9.(월) 09:00 ~ 17:00',
     stepNote: '(건강검진 관련서류 제출: 11. 9.(월) 17:00까지)',
     /** 수험표 표기 (admin TicketPage) */
-    ticketPeriod: '2026. 11. 04.(수)~ 11. 9.(월) 17:00',
+    ticketPeriod: '2026. 11. 04.(수)~ 11. 9.(월) 09:00 ~ 17:00',
   },
 
   /** 비전캠프 */


### PR DESCRIPTION
## 개요 💡

메인 페이지 모집절차의 합격자 등록 항목에 시작 시간이 누락되어 종료 시간만 노출되고 있어 이를 보완하였습니다.

## 작업내용 ⌨️

- `packages/constants/src/date.ts`의 `registration.stepEnd`에 시작 시간 `09:00`을 추가하였습니다.
- 동일한 기간을 표기하는 `registration.ticketPeriod`(어드민 수험표)도 함께 반영하였습니다.
- 표기 형식은 기존 원서 접수 항목과 동일하게 맞추었습니다.

**변경 전** → **변경 후**
- 모집절차: `2026. 11. 4.(수) ~ 11. 9.(월) 17:00` → `2026. 11. 4.(수) ~ 11. 9.(월) 09:00 ~ 17:00`
- 수험표: `2026. 11. 04.(수)~ 11. 9.(월) 17:00` → `2026. 11. 04.(수)~ 11. 9.(월) 09:00 ~ 17:00`
