### PR TITLE
[oneseo] 생기부 OCR 업로드를 S3 직접 업로드 방식으로 변경

### DIFF
--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -2,6 +2,12 @@ NEXT_PUBLIC_API_BASE_URL=running-url
 NEXT_PUBLIC_CHANNEL_IO_KEY=
 NEXT_PUBLIC_GOOGLE_ANALYTICS=
 
+# 생기부 OCR PDF가 업로드되는 S3 버킷 (school-record-ocr Route가 objectKey로 내려받을 때 사용)
+AWS_REGION=
+AWS_S3_BUCKET=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
 # Sentry (선택 - 계정 생성 후 값 채워 넣으면 활성화됩니다)
 NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_DSN=

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -11,6 +11,7 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1123.0",
     "@hookform/resolvers": "^5.2.2",
     "@repo/api": "workspace:*",
     "@repo/constants": "workspace:*",

--- a/apps/client/src/app/api/school-record-ocr/route.ts
+++ b/apps/client/src/app/api/school-record-ocr/route.ts
@@ -1,3 +1,4 @@
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { parse } from 'kordoc';
 import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
@@ -11,6 +12,10 @@ export const runtime = 'nodejs';
 
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
 
+// 파일은 브라우저에서 S3로 직접 PUT 업로드되고 이 라우트는 objectKey만 받는다 — Vercel
+// Function 요청 본문은 4.5MB 하드 캡이라 PDF를 이 라우트로 직접 흘려보낼 수 없다.
+const s3Client = new S3Client({ region: process.env.AWS_REGION });
+
 // axiosInstance의 응답 인터셉터가 백엔드(Java) 응답 형식({code, data, message, status})을
 // 가정하고 response.data.data를 꺼내 쓴다. 이 라우트도 같은 형식으로 감싸야 클라이언트의
 // 공용 post() 훅이 그대로 통한다.
@@ -18,10 +23,11 @@ const errorResponse = (message: string, status: number) =>
   NextResponse.json({ code: status, message, status: `${status}` }, { status });
 
 /**
- * 이 라우트는 인증·요청 제한 없이 그대로 두면 로그인 없이도 누구나 20MB짜리 OCR을 돌릴 수 있어
- * 리소스 남용에 노출된다(리뷰 지적). kordoc을 실행하기 전에 로그인 페이지들이 쓰는 것과 같은
- * SESSION 쿠키를 백엔드 인증 확인 엔드포인트로 검증해 비로그인 요청을 걷어낸다. 요청 빈도
- * 제한(rate limit)은 이 라우트 코드가 아니라 인프라(Vercel/백엔드) 쪽에서 적용하기로 했다.
+ * 이 라우트는 인증·요청 제한 없이 그대로 두면 로그인 없이도 누구나 S3에서 파일을 내려받아
+ * 20MB짜리 OCR을 돌릴 수 있어 리소스 남용에 노출된다(리뷰 지적). kordoc을 실행하기 전에
+ * 로그인 페이지들이 쓰는 것과 같은 SESSION 쿠키를 백엔드 인증 확인 엔드포인트로 검증해
+ * 비로그인 요청을 걷어낸다. 요청 빈도 제한(rate limit)은 이 라우트 코드가 아니라
+ * 인프라(Vercel/백엔드) 쪽에서 적용하기로 했다.
  */
 const isAuthenticated = async (): Promise<boolean> => {
   const session = (await cookies()).get('SESSION')?.value;
@@ -50,22 +56,31 @@ export async function POST(request: NextRequest) {
     return errorResponse('로그인이 필요합니다.', 401);
   }
 
-  const formData = await request.formData();
-  const file = formData.get('file');
+  const { objectKey } = (await request.json().catch(() => ({}))) as { objectKey?: string };
 
-  if (!(file instanceof File)) {
-    return errorResponse('파일이 없습니다.', 400);
+  if (!objectKey) {
+    return errorResponse('objectKey가 없습니다.', 400);
   }
 
-  if (file.type !== 'application/pdf') {
-    return errorResponse('PDF 파일만 지원합니다.', 400);
+  let buffer: Buffer;
+  try {
+    const object = await s3Client.send(
+      new GetObjectCommand({ Bucket: process.env.AWS_S3_BUCKET, Key: objectKey }),
+    );
+    const byteArray = await object.Body?.transformToByteArray();
+    if (!byteArray) {
+      throw new Error('empty S3 object body');
+    }
+    buffer = Buffer.from(byteArray);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[school-record-ocr] S3에서 파일을 내려받지 못함', error);
+    return errorResponse('업로드된 파일을 찾지 못했어요. 다시 업로드해주세요.', 404);
   }
 
-  if (file.size > MAX_FILE_SIZE) {
+  if (buffer.byteLength > MAX_FILE_SIZE) {
     return errorResponse('파일 용량은 20MB 이하만 지원합니다.', 400);
   }
-
-  const buffer = Buffer.from(await file.arrayBuffer());
 
   // 손상되거나 암호화된 PDF는 kordoc이 ParseFailure로 감싸 돌려주지 않고 그냥 throw할 수
   // 있다 — 감싸지 않으면 이 요청이 처리되지 않은 예외로 500이 되어, 사용자에게 "파일을

--- a/packages/api/src/hooks/oneseo/index.ts
+++ b/packages/api/src/hooks/oneseo/index.ts
@@ -16,6 +16,7 @@ export * from './usePostMockScore';
 export * from './usePostMyOneseo';
 export * from './usePostSchoolRecordExtraction';
 export * from './usePostSchoolRecordOcr';
+export * from './usePostSchoolRecordOcrUploadUrl';
 export * from './usePutMyOneseo';
 export * from './usePostTempStorage';
 export * from './usePutOneseoById';

--- a/packages/api/src/hooks/oneseo/usePostSchoolRecordOcr.ts
+++ b/packages/api/src/hooks/oneseo/usePostSchoolRecordOcr.ts
@@ -1,17 +1,15 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
-import { SchoolRecordOcrResponseType } from '@repo/types';
+import { SchoolRecordOcrRequestType, SchoolRecordOcrResponseType } from '@repo/types';
 
 import { oneseoQueryKeys, oneseoUrl, post } from '../../libs';
 
 export const usePostSchoolRecordOcr = (
-  options?: UseMutationOptions<SchoolRecordOcrResponseType, AxiosError, FormData>,
+  options?: UseMutationOptions<SchoolRecordOcrResponseType, AxiosError, SchoolRecordOcrRequestType>,
 ) =>
   useMutation({
     mutationKey: oneseoQueryKeys.postSchoolRecordOcr(),
-    // Content-Type을 직접 지정하지 않는다 — boundary 없이 명시하면 axios가 FormData를 보고
-    // boundary를 채워 넣는 걸 건너뛰어 서버가 멀티파트를 파싱하지 못할 수 있다.
     mutationFn: (data) => post<SchoolRecordOcrResponseType>(oneseoUrl.postSchoolRecordOcr(), data),
     ...options,
   });

--- a/packages/api/src/hooks/oneseo/usePostSchoolRecordOcrUploadUrl.ts
+++ b/packages/api/src/hooks/oneseo/usePostSchoolRecordOcrUploadUrl.ts
@@ -1,0 +1,18 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { SchoolRecordOcrUploadUrlResponseType } from '@repo/types';
+
+import { oneseoQueryKeys, oneseoUrl, post } from '../../libs';
+
+export const usePostSchoolRecordOcrUploadUrl = (
+  options?: UseMutationOptions<SchoolRecordOcrUploadUrlResponseType, AxiosError, string>,
+) =>
+  useMutation({
+    mutationKey: oneseoQueryKeys.postSchoolRecordOcrUploadUrl(),
+    mutationFn: (fileExtension) =>
+      post<SchoolRecordOcrUploadUrlResponseType>(
+        oneseoUrl.postSchoolRecordOcrUploadUrl(fileExtension),
+      ),
+    ...options,
+  });

--- a/packages/api/src/libs/queryKeys.ts
+++ b/packages/api/src/libs/queryKeys.ts
@@ -12,6 +12,7 @@ export const oneseoQueryKeys = {
   putOneseoByMemberId: (memberId: number) => ['put', 'oneseo', memberId],
   postImage: () => ['post', 'certification', 'image'],
   postSchoolRecordExtraction: () => ['post', 'school-record', 'extraction'],
+  postSchoolRecordOcrUploadUrl: () => ['post', 'school-record', 'ocr', 'upload-url'],
   postSchoolRecordOcr: () => ['post', 'school-record', 'ocr'],
   getSearchedOneseoList: (
     page: number,

--- a/packages/api/src/libs/requestUrlController.ts
+++ b/packages/api/src/libs/requestUrlController.ts
@@ -25,6 +25,9 @@ export const oneseoUrl = {
   putMyOneseo: () => '/oneseo/v3/oneseo/me',
   postImage: () => '/oneseo/v3/image',
   postSchoolRecordExtraction: () => '/oneseo/v3/extraction/middle-school-achievement',
+  /** 생기부 PDF를 S3에 직접 업로드하기 위한 presigned URL 발급 */
+  postSchoolRecordOcrUploadUrl: (fileExtension: string) =>
+    `/oneseo/v3/ocr-upload-url?fileExtension=${fileExtension}`,
   /** Java 백엔드가 아니라 이 Next.js 앱 자신의 API Route(kordoc 직접 호출)로 간다 */
   postSchoolRecordOcr: () => '/school-record-ocr',
   getOneseoByMemberId: (memberId: number) => `/oneseo/v3/oneseo/${memberId}`,

--- a/packages/types/src/schoolRecordExtraction.ts
+++ b/packages/types/src/schoolRecordExtraction.ts
@@ -56,7 +56,18 @@ export interface SchoolRecordExtractionResponseType {
   meta: SchoolRecordExtractionMetaType;
 }
 
-/** 생기부 PDF 전체를 Next.js API Route(kordoc)로 보내 인식한 결과 */
+/** 생기부 PDF를 S3에 직접 업로드하기 위한 presigned URL 발급 응답 */
+export interface SchoolRecordOcrUploadUrlResponseType {
+  uploadUrl: string;
+  objectKey: string;
+}
+
+/** S3에 업로드된 생기부 PDF의 objectKey를 Next.js API Route(kordoc)에 전달 */
+export interface SchoolRecordOcrRequestType {
+  objectKey: string;
+}
+
+/** 생기부 PDF를 Next.js API Route(kordoc)에서 인식한 결과 */
 export interface SchoolRecordOcrResponseType {
   rawText: string;
   unrecognizedSubjectBlobs: string[];

--- a/packages/ui/src/components/SchoolRecordUploader/index.tsx
+++ b/packages/ui/src/components/SchoolRecordUploader/index.tsx
@@ -4,7 +4,11 @@ import type { AxiosError } from 'axios';
 import { useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 
-import { usePostSchoolRecordExtraction, usePostSchoolRecordOcr } from '@repo/api/hooks';
+import {
+  usePostSchoolRecordExtraction,
+  usePostSchoolRecordOcr,
+  usePostSchoolRecordOcrUploadUrl,
+} from '@repo/api/hooks';
 import {
   GraduationTypeValueEnum,
   LiberalSystemValueEnum,
@@ -56,6 +60,7 @@ const SchoolRecordUploader = ({
 
   const { mutateAsync: extractSchoolRecord } = usePostSchoolRecordExtraction();
   const { mutateAsync: extractSchoolRecordOcr } = usePostSchoolRecordOcr();
+  const { mutateAsync: getSchoolRecordOcrUploadUrl } = usePostSchoolRecordOcrUploadUrl();
 
   const isProcessing = status === 'processing' || status === 'submitting';
 
@@ -80,9 +85,21 @@ const SchoolRecordUploader = ({
     setStatus('processing');
 
     try {
-      const formData = new FormData();
-      formData.append('file', file, file.name);
-      const extraction = await extractSchoolRecordOcr(formData);
+      // 4.5MB Vercel Function 요청 본문 제한을 피하기 위해 파일은 Vercel을 거치지 않고
+      // 브라우저에서 S3로 직접 PUT 업로드한다. Route에는 objectKey만 전달한다.
+      const { uploadUrl, objectKey } = await getSchoolRecordOcrUploadUrl('pdf');
+
+      const putResponse = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/pdf' },
+        body: file,
+      });
+
+      if (!putResponse.ok) {
+        throw new Error('파일 업로드에 실패했어요. 다시 시도해 주세요.');
+      }
+
+      const extraction = await extractSchoolRecordOcr({ objectKey });
 
       if (process.env.NODE_ENV !== 'production') {
         // eslint-disable-next-line no-console

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
 
   apps/client:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1123.0
+        version: 3.1123.0
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.7))
@@ -549,6 +552,78 @@ packages:
 
   '@apm-js-collab/tracing-hooks@0.13.0':
     resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
+
+  '@aws-sdk/checksums@3.1000.29':
+    resolution: {integrity: sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1123.0':
+    resolution: {integrity: sha512-InD/KXgF4clIFtqo8yzQQG755/BBoLstsC5WITLrMckKUUaACQgbpbZcdsySAXU3Uukp/3RV0Aiv5H3eDNGXcw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.82':
+    resolution: {integrity: sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    resolution: {integrity: sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2306,6 +2381,30 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.12.0':
+    resolution: {integrity: sha512-0mq1pHadfyXCYCqm2cNpbjNIT+fbaUpNxewZb/YNr2L0IrEVMOb8gM/Fl4K6XvHCW3uSNDFwPl/+iKm0bx9jYg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -2749,6 +2848,9 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -5470,6 +5572,171 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@aws-sdk/checksums@3.1000.29':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1123.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.29
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.82
+      '@aws-sdk/middleware-sdk-s3': 3.972.75
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.12.0
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.12.0
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.82':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.12.0
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -7102,6 +7369,39 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.12.0':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
@@ -7584,6 +7884,8 @@ snapshots:
 
   boolean@3.2.0:
     optional: true
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
     dependencies:


### PR DESCRIPTION
## 개요 💡

생기부 OCR 업로드 시 개발 환경에서 발생하던 `413` 오류의 실제 원인은 Vercel Function의 요청 본문 크기 제한(`4.5MB`, Fluid Compute 활성화 여부와 무관하게 고정)이었습니다. 기존에는 PDF 파일 전체를 `multipart/form-data`로 Vercel Function(`/api/school-record-ocr`)에 직접 전송하고 있어, 이 제한을 넘는 파일은 코드 실행 전에 플랫폼 단에서 차단되었습니다. 백엔드팀과 협의하여 파일을 S3에 직접 업로드하는 구조로 변경하였습니다.

## 작업내용 ⌨️

- `POST /oneseo/v3/ocr-upload-url?fileExtension=pdf`를 호출해 `{ uploadUrl, objectKey }`를 발급받는 `usePostSchoolRecordOcrUploadUrl` 훅을 추가하였습니다.
- `SchoolRecordUploader`의 업로드 흐름을 변경하였습니다: 파일을 Vercel Function에 보내는 대신, 발급받은 `uploadUrl`로 브라우저에서 S3에 직접 `PUT` 업로드한 뒤 `objectKey`만 `/api/school-record-ocr`에 전달합니다.
- `apps/client/src/app/api/school-record-ocr/route.ts`가 더 이상 `formData`로 파일을 받지 않고, JSON으로 받은 `objectKey`를 이용해 `@aws-sdk/client-s3`로 S3에서 파일을 직접 내려받아 `kordoc`을 실행하도록 변경하였습니다.
- `usePostSchoolRecordOcr`의 요청 타입을 `FormData`에서 `SchoolRecordOcrRequestType({ objectKey })`으로 변경하였습니다.
- `@aws-sdk/client-s3` 의존성과 `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` 환경변수를 `.env.example`에 추가하였습니다.

## 관련 이슈 🚨

- 백엔드팀이 공유해준 구조도를 기반으로 구현하였으나, 아래 세부 계약은 아직 확답을 받지 못해 기존 코드 컨벤션을 참고해 추정한 값입니다. 실제 API와 다르면 조정이 필요합니다.
  - `ocr-upload-url` 엔드포인트의 정확한 전체 경로 및 인증(`SESSION` 쿠키) 필요 여부
  - 응답 필드명(`uploadUrl`, `objectKey`)의 정확한 casing
  - S3 PUT 업로드 시 필요한 헤더 및 버킷 CORS 설정 여부
  - `school-record-ocr` Route가 S3에 직접 SDK로 접근하는 방식이 맞는지(자격증명 발급 방법 포함), 아니면 별도 다운로드 URL을 받아야 하는지
  - 업로드된 파일의 정리(cleanup) 주체(백엔드 TTL vs 프론트 명시적 삭제)
- 관련하여 `fix/school-record-ocr-file-size-limit`(#458) PR도 함께 진행 중이며, 이 PR과는 독립적으로 파일 용량 제한값(`20MB`/`30MB`)을 다루고 있어 병합 순서에 따라 값 충돌이 발생할 수 있습니다.

## 리뷰 요청사항 👀

- `AWS_REGION`/`AWS_S3_BUCKET` 자격증명을 Next.js 서버(Vercel Function) 환경변수로 직접 노출하는 현재 구조가 적절한지 검토 부탁드립니다.
- 백엔드 계약 확정 후 실제 값으로 맞춰야 하는 부분이 있어, 병합 전 백엔드팀 확인이 필요합니다.
