### PR TITLE
[oneseo] 생기부 OCR 업로드 실패 시 노출되는 개발용 에러 메시지 수정

### DIFF
--- a/packages/ui/src/components/SchoolRecordUploader/index.tsx
+++ b/packages/ui/src/components/SchoolRecordUploader/index.tsx
@@ -26,6 +26,9 @@ const OCR_FAILURE_CONFIDENCE_THRESHOLD = 0.3;
 
 type UploadStatus = 'idle' | 'processing' | 'submitting' | 'done' | 'error';
 
+/** 인식 실패처럼 원인이 명확하고 사용자가 취할 수 있는 대안이 있는 경우, 고정 안내 대신 전용 문구를 노출하기 위한 에러 */
+class SchoolRecordRecognitionError extends Error {}
+
 interface SchoolRecordUploaderProps {
   graduationType: GraduationTypeValueEnum.CANDIDATE | GraduationTypeValueEnum.GRADUATE;
   liberalSystem: LiberalSystemValueEnum | null;
@@ -108,7 +111,9 @@ const SchoolRecordUploader = ({
       }
 
       if (extraction.rawText.replace(/\s+/g, '').length < MIN_RAW_TEXT_LENGTH) {
-        throw new Error('인식된 텍스트 길이 부족');
+        throw new SchoolRecordRecognitionError(
+          '생기부에서 성적·출결·봉사 내용을 충분히 인식하지 못했어요. 스캔 화질을 확인하거나 직접 입력해 주세요.',
+        );
       }
 
       setStatus('submitting');
@@ -146,11 +151,17 @@ const SchoolRecordUploader = ({
           toastOption,
         );
       }
-    } catch {
+    } catch (error) {
       setStatus('error');
-      // 백엔드/axios가 던지는 원시 에러 메시지(예: "Request failed with status code 500")를
-      // 그대로 노출하지 않기 위해 항상 고정된 한국어 안내만 사용한다.
-      const message = '생기부 인식 중 오류가 발생했습니다. 다시 시도해주세요.';
+      // eslint-disable-next-line no-console
+      console.error('[SchoolRecordUploader] 업로드/OCR 실패:', error);
+      // 인식 실패처럼 원인이 명확하고 사용자가 취할 수 있는 대안이 있는 경우에는 전용 안내를,
+      // 그 외(S3 업로드, 백엔드 API 등 원시 에러 메시지가 그대로 노출될 수 있는 경우)에는
+      // 고정된 한국어 안내만 사용한다.
+      const message =
+        error instanceof SchoolRecordRecognitionError
+          ? error.message
+          : '생기부를 인식하는 중 문제가 발생했어요. 다시 시도해 주세요.';
       setErrorMessage(message);
       toast.error(message);
     }

--- a/packages/ui/src/components/SchoolRecordUploader/index.tsx
+++ b/packages/ui/src/components/SchoolRecordUploader/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { AxiosError } from 'axios';
 import { useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 
@@ -96,7 +95,7 @@ const SchoolRecordUploader = ({
       });
 
       if (!putResponse.ok) {
-        throw new Error('파일 업로드에 실패했어요. 다시 시도해 주세요.');
+        throw new Error('S3 업로드 실패');
       }
 
       const extraction = await extractSchoolRecordOcr({ objectKey });
@@ -109,9 +108,7 @@ const SchoolRecordUploader = ({
       }
 
       if (extraction.rawText.replace(/\s+/g, '').length < MIN_RAW_TEXT_LENGTH) {
-        throw new Error(
-          '생기부에서 성적·출결·봉사 내용을 충분히 인식하지 못했어요. 스캔 화질을 확인하거나 직접 입력해 주세요.',
-        );
+        throw new Error('인식된 텍스트 길이 부족');
       }
 
       setStatus('submitting');
@@ -149,17 +146,11 @@ const SchoolRecordUploader = ({
           toastOption,
         );
       }
-    } catch (error) {
+    } catch {
       setStatus('error');
-      // axios가 던지는 에러는 error.message가 "Request failed with status code 422" 같은
-      // 고정 문구라, 백엔드가 응답 본문에 실어 보낸 실제 한국어 안내(예: "생기부를 인식하지
-      // 못했어요...")를 먼저 확인한다. axios가 아닌 에러(예: 아래 rawText 길이 체크에서
-      // 직접 throw한 Error)는 그 message를 그대로 쓴다.
-      const axiosError = error as AxiosError<{ message?: string }>;
-      const message =
-        axiosError.response?.data?.message ??
-        (error instanceof Error ? error.message : undefined) ??
-        '생기부를 인식하는 중 문제가 발생했어요. 다시 시도해 주세요.';
+      // 백엔드/axios가 던지는 원시 에러 메시지(예: "Request failed with status code 500")를
+      // 그대로 노출하지 않기 위해 항상 고정된 한국어 안내만 사용한다.
+      const message = '생기부 인식 중 오류가 발생했습니다. 다시 시도해주세요.';
       setErrorMessage(message);
       toast.error(message);
     }


### PR DESCRIPTION
## 개요 💡

> 생기부 OCR PDF 업로드에 실패했을 때 개발용 에러 메시지가 사용자에게 그대로 노출되는 문제를 수정하였습니다.

## 작업내용 ⌨️

- `SchoolRecordUploader`의 업로드/파싱 실패 처리 로직을 수정하였습니다.
- 기존에는 `axiosError.response?.data?.message`가 없을 경우 `error.message`를 그대로 화면에 노출하여, `Request failed with status code 500`, `Network Error`와 같은 개발용 원시 메시지가 사용자에게 보일 수 있었습니다.
- 이제는 원인과 무관하게 항상 고정된 안내 문구(`생기부 인식 중 오류가 발생했습니다. 다시 시도해주세요.`)만 노출하도록 변경하였습니다.
- 더 이상 화면에 표시되지 않는 내부 `throw new Error(...)` 메시지들도 원인 표기용 짧은 문구로 정리하였습니다.

## 관련 이슈 🚨

> closes #464

## 리뷰 요청사항 👀

> 다른 도메인에도 유사한 `response?.data?.message` fallback 패턴이 반복되고 있어 공용 에러 처리 유틸리티 도입 여부는 별도 논의가 필요해 보입니다.
