### PR TITLE
[fix] 생기부 OCR presigned URL 경로 및 Vercel 배포 시 OCR 빈 텍스트 문제 수정

### DIFF
--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -4,6 +4,21 @@ import { withSentryConfig } from '@sentry/nextjs';
 
 const nextConfig = {
   reactCompiler: true,
+  // kordoc(OCR)과 그 하위 의존성(@napi-rs/canvas, onnxruntime-node, sharp 등)은 플랫폼별
+  // 네이티브 바이너리를 포함한 패키지다. Next.js가 이런 패키지를 서버리스 함수용으로 직접
+  // 번들링하려고 하면 네이티브 바이너리 파일이 트레이싱에서 빠지는 경우가 흔하다 — 실제로
+  // Vercel 배포에서 "Cannot polyfill `Path2D`"(@napi-rs/canvas 로드 실패) 경고와 함께
+  // PDF 렌더링이 깨져 OCR 결과가 빈 문자열로 나오는 문제가 있었다. serverExternalPackages로
+  // 지정하면 번들링하지 않고 런타임에 node_modules에서 그대로 require하게 되어, pnpm이
+  // 설치해 둔 실제 플랫폼(Linux)용 바이너리를 정상적으로 찾는다.
+  serverExternalPackages: [
+    'kordoc',
+    '@napi-rs/canvas',
+    'onnxruntime-node',
+    'sharp',
+    '@huggingface/transformers',
+    '@hyzyla/pdfium',
+  ],
   images: {
     remotePatterns: [
       {

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -16,3 +16,8 @@ words:
   - pdfjs
   - kordoc
   - bbox
+  - napi
+  - onnxruntime
+  - huggingface
+  - hyzyla
+  - pdfium


### PR DESCRIPTION
## 개요 💡

merge된 생기부 OCR 자동입력 기능(#451)이 실제 stage/production 배포 환경에서 두 가지 문제로 동작하지 않던 것을 수정합니다.

## 작업내용 ⌨️

**presigned URL 요청 경로 수정 (754c19d6)**

- `postSchoolRecordOcrUploadUrl`이 잘못된 백엔드 경로(`/oneseo/v3/ocr-upload-url`)를 호출하고 있어 수정 (`/oneseo/v3/extraction/middle-school-achievement/ocr-upload-url`)

**Vercel 배포에서 OCR이 항상 빈 텍스트를 반환하던 문제 수정 (dc746eac)**

- 증상: stage/production 둘 다에서 `/api/school-record-ocr`이 200 OK를 반환하지만 `rawText`가 항상 빈 문자열
- 원인: Vercel 함수 로그에 `Cannot polyfill \`Path2D\`, rendering may be broken` 경고가 찍혀 있었음 — pdfjs-dist가 PDF 페이지를 이미지로 렌더링할 때 쓰는 `@napi-rs/canvas` 로드에 실패한다는 뜻. 페이지 렌더링이 안 되면 OCR이 인식할 이미지 자체가 없어 결과가 항상 빈 문자열이 됨
- kordoc과 하위 네이티브 바이너리 의존성(`@napi-rs/canvas`, `onnxruntime-node`, `sharp`, `@huggingface/transformers`, `@hyzyla/pdfium`)은 플랫폼별 네이티브 바이너리를 포함하는데, Next.js가 서버리스 함수로 번들링할 때 이런 바이너리 파일을 트레이싱에서 빠뜨리는 경우가 흔함
- `next.config.mjs`에 `serverExternalPackages`로 지정해 번들링하지 않고 런타임에 `node_modules`에서 그대로 `require`하도록 변경 — pnpm이 Vercel 빌드 시 설치한 실제 Linux용 네이티브 바이너리를 정상적으로 찾게 됨

이 외에도 이번에 진단하면서 별도로 AWS 환경변수(`AWS_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) 및 `KORDOC_MODEL_CACHE=/tmp/kordoc-models`를 Vercel 프로젝트(stage/production)에 추가했습니다 — 이건 코드가 아니라 Vercel 프로젝트 설정이라 이 PR에는 포함되지 않습니다.

## 스크린샷/동영상 📸

없음

## 관련 이슈 🚨

#451 (생기부 OCR 자동입력) 배포 후 발견된 후속 버그

## 리뷰 요청사항 👀

- `serverExternalPackages` 목록이 실제로 Vercel 배포에서 `Path2D` 경고를 없애고 `rawText`를 정상적으로 채우는지, 이 PR이 머지된 뒤 stage 재배포로 다시 확인이 필요합니다.
- 콜드 스타트마다 OCR 모델(~19MB)을 Hugging Face에서 다시 받아야 하는 구조라, 첫 요청이 느릴 수 있습니다 — 실제 실행 시간이 계속 오래 걸리면 `maxDuration` 조정이나 모델 프리로딩 전략이 추가로 필요할 수 있습니다.