### PR TITLE
[fix] Vercel 배포에서 OCR 네이티브 의존성이 빠지던 문제 수정

### DIFF
--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -21,7 +21,13 @@ const nextConfig = {
   // 동시에 선언해) 두 버전이 pnpm 스토어에 공존하는데 각 버전의 bin/ 안에 linux/darwin/win32
   // (DirectML.dll 포함) 바이너리가 전부 들어 있어 버전당 200MB 이상이었다. Vercel 서버리스
   // 런타임은 glibc 기반 Linux x64뿐이므로, 실제 실행에 필요한 linux-x64-gnu 바이너리만
-  // 남기고 나머지 플랫폼은 제외하도록 패턴을 좁혔다.
+  // 남기고 나머지 플랫폼은 제외하도록 패턴을 좁혔더니 599MB로 줄었지만 여전히 초과했다.
+  // 남은 원인은 `kordoc*/**/*` 패턴 — pnpm은 kordoc 패키지 디렉터리 옆에 그 직접/옵셔널
+  // 의존성(onnxruntime-node, sharp, @huggingface/transformers, @hyzyla/pdfium 등)을 가리키는
+  // 심볼릭 링크를 함께 두는데, `**/*` 글롭이 이 심볼릭 링크를 그대로 따라 들어가면서 이미
+  // 좁혀둔 onnxruntime-node를 플랫폼 제한 없이(258MB) 통째로 다시 포함시키고 있었다. kordoc
+  // 자체 코드만 남기고, kordoc이 필요로 하는 나머지 옵셔널 의존성(@huggingface/transformers,
+  // @hyzyla/pdfium — 둘 다 순수 JS/WASM이라 플랫폼 분기가 없다)은 별도 패턴으로 명시했다.
   serverExternalPackages: [
     'kordoc',
     '@napi-rs/canvas',
@@ -41,7 +47,9 @@ const nextConfig = {
       '../../node_modules/.pnpm/sharp@*/**/*',
       '../../node_modules/.pnpm/@img+sharp-linux-x64@*/**/*',
       '../../node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/**/*',
-      '../../node_modules/.pnpm/kordoc*/**/*',
+      '../../node_modules/.pnpm/kordoc@*/node_modules/kordoc/**/*',
+      '../../node_modules/.pnpm/@huggingface+transformers@*/**/*',
+      '../../node_modules/.pnpm/@hyzyla+pdfium@*/**/*',
     ],
   },
   images: {

--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -5,55 +5,20 @@ import { withSentryConfig } from '@sentry/nextjs';
 const nextConfig = {
   reactCompiler: true,
   // kordoc(OCR)과 그 하위 의존성(@napi-rs/canvas, onnxruntime-node, sharp 등)은 플랫폼별
-  // 네이티브 바이너리를 포함한 패키지다. serverExternalPackages만으로는 부족했다 — 실제
-  // Vercel 배포 로그로 확인해보니 "Cannot find module '@napi-rs/canvas'"였다. pdfjs-dist가
-  // 이 패키지를 try/catch로 감싸 선택적으로 require하다 보니, Next.js의 자동 파일 트레이싱이
-  // "없어도 되는 optional require"로 보고 배포 번들에 아예 안 넣어버린 것 — @napi-rs/canvas가
-  // apps/client의 직접 의존성이 아니라 pdfjs-dist의 선택적 하위 의존성이라 더 그렇다. 그
-  // 결과 DOMMatrix/ImageData/Path2D 폴리필이 전부 실패해 PDF 페이지를 이미지로 렌더링하지
-  // 못하고, OCR이 읽을 이미지 자체가 없어 rawText가 항상 빈 문자열이었다.
-  // outputFileTracingIncludes로 이 라우트에 필요한 파일을 명시적으로 강제 포함시킨다.
-  //
-  // 와일드카드(`@napi-rs+canvas*`, `onnxruntime-node*`, `@img+sharp*`)로 처음 포함시켰더니
-  // 함수 크기가 961MB까지 부풀어 Vercel의 250MB 제한을 넘겼다. 원인: @napi-rs/canvas는
-  // darwin/android/windows 등 10개 플랫폼 패키지가 전부 매칭됐고, onnxruntime-node는
-  // (@huggingface/transformers가 1.24.3을 dependencies로, 1.27.0을 optionalDependencies로
-  // 동시에 선언해) 두 버전이 pnpm 스토어에 공존하는데 각 버전의 bin/ 안에 linux/darwin/win32
-  // (DirectML.dll 포함) 바이너리가 전부 들어 있어 버전당 200MB 이상이었다. linux-x64-gnu로
-  // 좁혔더니 599MB로 줄었지만 여전히 초과했다 — kordoc*/**/* 글롭이 kordoc 옆의 의존성
-  // 심볼릭 링크를 따라 들어가 onnxruntime-node를 다시 통째로 포함시켰다.
-  //
-  // kordoc 패턴을 kordoc 자체 폴더로 좁히고 @huggingface/transformers·@hyzyla/pdfium을 명시
-  // 포함시켰는데도 621MB(VERCEL_ANALYZE_BUILD_OUTPUT=1 리포트 기준)였다. 리포트로 확인한
-  // 실제 원인: @huggingface/transformers@4.2.0 하나가 348MB — 그 패키지 옆에도 심볼릭 링크로
-  // onnxruntime-web(웹용 WASM 런타임), 별도 버전의 onnxruntime-node(1.24.3)·sharp(0.34.5)가
-  // 딸려 있었다. kordoc 소스(dist/formula-*.cjs)를 직접 읽어 확인한 결과 @huggingface/
-  // transformers와 @hyzyla/pdfium은 kordoc의 `formulaOcr` 옵션(수식 인식 전용, 기본 false)에서만
-  // tryImport로 로드되고, 우리 라우트는 `parse(buffer, { ocr: true, tables: true })`만 호출해
-  // formulaOcr을 켜지 않으므로 애초에 불필요했다 — 완전히 제외했다. 실제 이미지 OCR 경로
-  // (dist/image-ocr-*.cjs가 require하는 내부 청크)가 쓰는 건 sharp와 onnxruntime-node뿐이며,
-  // kordoc 옆 심볼릭 링크가 실제로 가리키는 버전은 onnxruntime-node@1.27.0·sharp@0.35.3라
-  // (1.24.3/0.34.5는 transformers 전용) 그 버전만 남기도록 고정했다.
+  // 네이티브 바이너리를 포함한 패키지다. Next.js가 이런 패키지를 서버리스 함수용으로 직접
+  // 번들링하려고 하면 네이티브 바이너리 파일이 트레이싱에서 빠지는 경우가 흔하다 — 실제로
+  // Vercel 배포에서 "Cannot polyfill `Path2D`"(@napi-rs/canvas 로드 실패) 경고와 함께
+  // PDF 렌더링이 깨져 OCR 결과가 빈 문자열로 나오는 문제가 있었다. serverExternalPackages로
+  // 지정하면 번들링하지 않고 런타임에 node_modules에서 그대로 require하게 되어, pnpm이
+  // 설치해 둔 실제 플랫폼(Linux)용 바이너리를 정상적으로 찾는다.
   serverExternalPackages: [
     'kordoc',
     '@napi-rs/canvas',
     'onnxruntime-node',
     'sharp',
+    '@huggingface/transformers',
+    '@hyzyla/pdfium',
   ],
-  outputFileTracingIncludes: {
-    '/api/school-record-ocr': [
-      '../../node_modules/.pnpm/@napi-rs+canvas@*/node_modules/@napi-rs/canvas/**/*',
-      '../../node_modules/.pnpm/@napi-rs+canvas-linux-x64-gnu@*/**/*',
-      '../../node_modules/.pnpm/onnxruntime-node@1.27.0/node_modules/onnxruntime-node/package.json',
-      '../../node_modules/.pnpm/onnxruntime-node@1.27.0/node_modules/onnxruntime-node/dist/**/*',
-      '../../node_modules/.pnpm/onnxruntime-node@1.27.0/node_modules/onnxruntime-node/lib/**/*',
-      '../../node_modules/.pnpm/onnxruntime-node@1.27.0/node_modules/onnxruntime-node/bin/napi-v6/linux/x64/**/*',
-      '../../node_modules/.pnpm/sharp@0.35.3*/**/*',
-      '../../node_modules/.pnpm/@img+sharp-linux-x64@0.35.3/**/*',
-      '../../node_modules/.pnpm/@img+sharp-libvips-linux-x64@1.3.2/**/*',
-      '../../node_modules/.pnpm/kordoc@*/node_modules/kordoc/**/*',
-    ],
-  },
   images: {
     remotePatterns: [
       {

--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -19,37 +19,39 @@ const nextConfig = {
   // darwin/android/windows 등 10개 플랫폼 패키지가 전부 매칭됐고, onnxruntime-node는
   // (@huggingface/transformers가 1.24.3을 dependencies로, 1.27.0을 optionalDependencies로
   // 동시에 선언해) 두 버전이 pnpm 스토어에 공존하는데 각 버전의 bin/ 안에 linux/darwin/win32
-  // (DirectML.dll 포함) 바이너리가 전부 들어 있어 버전당 200MB 이상이었다. Vercel 서버리스
-  // 런타임은 glibc 기반 Linux x64뿐이므로, 실제 실행에 필요한 linux-x64-gnu 바이너리만
-  // 남기고 나머지 플랫폼은 제외하도록 패턴을 좁혔더니 599MB로 줄었지만 여전히 초과했다.
-  // 남은 원인은 `kordoc*/**/*` 패턴 — pnpm은 kordoc 패키지 디렉터리 옆에 그 직접/옵셔널
-  // 의존성(onnxruntime-node, sharp, @huggingface/transformers, @hyzyla/pdfium 등)을 가리키는
-  // 심볼릭 링크를 함께 두는데, `**/*` 글롭이 이 심볼릭 링크를 그대로 따라 들어가면서 이미
-  // 좁혀둔 onnxruntime-node를 플랫폼 제한 없이(258MB) 통째로 다시 포함시키고 있었다. kordoc
-  // 자체 코드만 남기고, kordoc이 필요로 하는 나머지 옵셔널 의존성(@huggingface/transformers,
-  // @hyzyla/pdfium — 둘 다 순수 JS/WASM이라 플랫폼 분기가 없다)은 별도 패턴으로 명시했다.
+  // (DirectML.dll 포함) 바이너리가 전부 들어 있어 버전당 200MB 이상이었다. linux-x64-gnu로
+  // 좁혔더니 599MB로 줄었지만 여전히 초과했다 — kordoc*/**/* 글롭이 kordoc 옆의 의존성
+  // 심볼릭 링크를 따라 들어가 onnxruntime-node를 다시 통째로 포함시켰다.
+  //
+  // kordoc 패턴을 kordoc 자체 폴더로 좁히고 @huggingface/transformers·@hyzyla/pdfium을 명시
+  // 포함시켰는데도 621MB(VERCEL_ANALYZE_BUILD_OUTPUT=1 리포트 기준)였다. 리포트로 확인한
+  // 실제 원인: @huggingface/transformers@4.2.0 하나가 348MB — 그 패키지 옆에도 심볼릭 링크로
+  // onnxruntime-web(웹용 WASM 런타임), 별도 버전의 onnxruntime-node(1.24.3)·sharp(0.34.5)가
+  // 딸려 있었다. kordoc 소스(dist/formula-*.cjs)를 직접 읽어 확인한 결과 @huggingface/
+  // transformers와 @hyzyla/pdfium은 kordoc의 `formulaOcr` 옵션(수식 인식 전용, 기본 false)에서만
+  // tryImport로 로드되고, 우리 라우트는 `parse(buffer, { ocr: true, tables: true })`만 호출해
+  // formulaOcr을 켜지 않으므로 애초에 불필요했다 — 완전히 제외했다. 실제 이미지 OCR 경로
+  // (dist/image-ocr-*.cjs가 require하는 내부 청크)가 쓰는 건 sharp와 onnxruntime-node뿐이며,
+  // kordoc 옆 심볼릭 링크가 실제로 가리키는 버전은 onnxruntime-node@1.27.0·sharp@0.35.3라
+  // (1.24.3/0.34.5는 transformers 전용) 그 버전만 남기도록 고정했다.
   serverExternalPackages: [
     'kordoc',
     '@napi-rs/canvas',
     'onnxruntime-node',
     'sharp',
-    '@huggingface/transformers',
-    '@hyzyla/pdfium',
   ],
   outputFileTracingIncludes: {
     '/api/school-record-ocr': [
-      '../../node_modules/.pnpm/@napi-rs+canvas@*/**/*',
+      '../../node_modules/.pnpm/@napi-rs+canvas@*/node_modules/@napi-rs/canvas/**/*',
       '../../node_modules/.pnpm/@napi-rs+canvas-linux-x64-gnu@*/**/*',
-      '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/package.json',
-      '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/dist/**/*',
-      '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/lib/**/*',
-      '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/bin/napi-v6/linux/x64/**/*',
-      '../../node_modules/.pnpm/sharp@*/**/*',
-      '../../node_modules/.pnpm/@img+sharp-linux-x64@*/**/*',
-      '../../node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/**/*',
+      '../../node_modules/.pnpm/onnxruntime-node@1.27.0/node_modules/onnxruntime-node/package.json',
+      '../../node_modules/.pnpm/onnxruntime-node@1.27.0/node_modules/onnxruntime-node/dist/**/*',
+      '../../node_modules/.pnpm/onnxruntime-node@1.27.0/node_modules/onnxruntime-node/lib/**/*',
+      '../../node_modules/.pnpm/onnxruntime-node@1.27.0/node_modules/onnxruntime-node/bin/napi-v6/linux/x64/**/*',
+      '../../node_modules/.pnpm/sharp@0.35.3*/**/*',
+      '../../node_modules/.pnpm/@img+sharp-linux-x64@0.35.3/**/*',
+      '../../node_modules/.pnpm/@img+sharp-libvips-linux-x64@1.3.2/**/*',
       '../../node_modules/.pnpm/kordoc@*/node_modules/kordoc/**/*',
-      '../../node_modules/.pnpm/@huggingface+transformers@*/**/*',
-      '../../node_modules/.pnpm/@hyzyla+pdfium@*/**/*',
     ],
   },
   images: {

--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -5,12 +5,14 @@ import { withSentryConfig } from '@sentry/nextjs';
 const nextConfig = {
   reactCompiler: true,
   // kordoc(OCR)과 그 하위 의존성(@napi-rs/canvas, onnxruntime-node, sharp 등)은 플랫폼별
-  // 네이티브 바이너리를 포함한 패키지다. Next.js가 이런 패키지를 서버리스 함수용으로 직접
-  // 번들링하려고 하면 네이티브 바이너리 파일이 트레이싱에서 빠지는 경우가 흔하다 — 실제로
-  // Vercel 배포에서 "Cannot polyfill `Path2D`"(@napi-rs/canvas 로드 실패) 경고와 함께
-  // PDF 렌더링이 깨져 OCR 결과가 빈 문자열로 나오는 문제가 있었다. serverExternalPackages로
-  // 지정하면 번들링하지 않고 런타임에 node_modules에서 그대로 require하게 되어, pnpm이
-  // 설치해 둔 실제 플랫폼(Linux)용 바이너리를 정상적으로 찾는다.
+  // 네이티브 바이너리를 포함한 패키지다. serverExternalPackages만으로는 부족했다 — 실제
+  // Vercel 배포 로그로 확인해보니 "Cannot find module '@napi-rs/canvas'"였다. pdfjs-dist가
+  // 이 패키지를 try/catch로 감싸 선택적으로 require하다 보니, Next.js의 자동 파일 트레이싱이
+  // "없어도 되는 optional require"로 보고 배포 번들에 아예 안 넣어버린 것 — @napi-rs/canvas가
+  // apps/client의 직접 의존성이 아니라 pdfjs-dist의 선택적 하위 의존성이라 더 그렇다. 그
+  // 결과 DOMMatrix/ImageData/Path2D 폴리필이 전부 실패해 PDF 페이지를 이미지로 렌더링하지
+  // 못하고, OCR이 읽을 이미지 자체가 없어 rawText가 항상 빈 문자열이었다.
+  // outputFileTracingIncludes로 이 라우트에 필요한 파일을 명시적으로 강제 포함시킨다.
   serverExternalPackages: [
     'kordoc',
     '@napi-rs/canvas',
@@ -19,6 +21,14 @@ const nextConfig = {
     '@huggingface/transformers',
     '@hyzyla/pdfium',
   ],
+  outputFileTracingIncludes: {
+    '/api/school-record-ocr': [
+      '../../node_modules/.pnpm/@napi-rs+canvas*/**/*',
+      '../../node_modules/.pnpm/onnxruntime-node*/**/*',
+      '../../node_modules/.pnpm/@img+sharp*/**/*',
+      '../../node_modules/.pnpm/kordoc*/**/*',
+    ],
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -13,6 +13,15 @@ const nextConfig = {
   // 결과 DOMMatrix/ImageData/Path2D 폴리필이 전부 실패해 PDF 페이지를 이미지로 렌더링하지
   // 못하고, OCR이 읽을 이미지 자체가 없어 rawText가 항상 빈 문자열이었다.
   // outputFileTracingIncludes로 이 라우트에 필요한 파일을 명시적으로 강제 포함시킨다.
+  //
+  // 와일드카드(`@napi-rs+canvas*`, `onnxruntime-node*`, `@img+sharp*`)로 처음 포함시켰더니
+  // 함수 크기가 961MB까지 부풀어 Vercel의 250MB 제한을 넘겼다. 원인: @napi-rs/canvas는
+  // darwin/android/windows 등 10개 플랫폼 패키지가 전부 매칭됐고, onnxruntime-node는
+  // (@huggingface/transformers가 1.24.3을 dependencies로, 1.27.0을 optionalDependencies로
+  // 동시에 선언해) 두 버전이 pnpm 스토어에 공존하는데 각 버전의 bin/ 안에 linux/darwin/win32
+  // (DirectML.dll 포함) 바이너리가 전부 들어 있어 버전당 200MB 이상이었다. Vercel 서버리스
+  // 런타임은 glibc 기반 Linux x64뿐이므로, 실제 실행에 필요한 linux-x64-gnu 바이너리만
+  // 남기고 나머지 플랫폼은 제외하도록 패턴을 좁혔다.
   serverExternalPackages: [
     'kordoc',
     '@napi-rs/canvas',
@@ -23,9 +32,15 @@ const nextConfig = {
   ],
   outputFileTracingIncludes: {
     '/api/school-record-ocr': [
-      '../../node_modules/.pnpm/@napi-rs+canvas*/**/*',
-      '../../node_modules/.pnpm/onnxruntime-node*/**/*',
-      '../../node_modules/.pnpm/@img+sharp*/**/*',
+      '../../node_modules/.pnpm/@napi-rs+canvas@*/**/*',
+      '../../node_modules/.pnpm/@napi-rs+canvas-linux-x64-gnu@*/**/*',
+      '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/package.json',
+      '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/dist/**/*',
+      '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/lib/**/*',
+      '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/bin/napi-v6/linux/x64/**/*',
+      '../../node_modules/.pnpm/sharp@*/**/*',
+      '../../node_modules/.pnpm/@img+sharp-linux-x64@*/**/*',
+      '../../node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/**/*',
       '../../node_modules/.pnpm/kordoc*/**/*',
     ],
   },

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -21,3 +21,4 @@ words:
   - huggingface
   - hyzyla
   - pdfium
+  - libvips

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,9 @@ packages:
   - packages/*
 
 onlyBuiltDependencies:
+  - '@sentry/cli'
   - msw
+  - onnxruntime-node
+  - protobufjs
   - sharp
   - unrs-resolver

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,18 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
+    "client#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
+      "env": [
+        "AWS_REGION",
+        "AWS_S3_BUCKET",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "KORDOC_MODEL_CACHE"
+      ]
+    },
     "lint": {
       "dependsOn": ["^lint"]
     },


### PR DESCRIPTION
## 개요 💡

#468에서 `serverExternalPackages`를 추가했는데도 stage에서 `rawText`가 계속 빈 문자열로 나와, Vercel 함수 로그를 직접 확인해 진짜 원인을 찾아 고쳤습니다.

## 작업내용 ⌨️

Vercel 함수 로그에서 실제 에러를 확인했습니다.

```
Warning: Cannot load "@napi-rs/canvas" package: "Error: Cannot find module '@napi-rs/canvas'
Require stack:
- /var/task/node_modules/.pnpm/pdfjs-dist@4.10.38/node_modules/pdfjs-dist/legacy/build/pdf.mjs"
Warning: Cannot polyfill `DOMMatrix`, rendering may be broken.
Warning: Cannot polyfill `ImageData`, rendering may be broken.
Warning: Cannot polyfill `Path2D`, rendering may be broken.
```

`serverExternalPackages`는 번들링만 막을 뿐, Vercel 배포 패키지에 실제로 어떤 파일을 포함시킬지는 Next.js의 자동 파일 트레이싱(`@vercel/nft`)이 별도로 결정합니다. `pdfjs-dist`가 `@napi-rs/canvas`를 `try/catch`로 감싸 선택적으로 `require`하다 보니, 트레이싱이 이를 "없어도 되는 optional require"로 판단해 배포 번들에서 통째로 빠뜨리고 있었습니다 — `@napi-rs/canvas`가 `apps/client`의 직접 의존성이 아니라 `pdfjs-dist`의 선택적 하위 의존성이라 더 그렇습니다.

이 폴리필들이 전부 실패하면 PDF 페이지를 이미지로 렌더링하지 못해 OCR이 읽을 이미지 자체가 없고, 그래서 `rawText`가 항상 빈 문자열이었습니다.

`next.config.mjs`에 `outputFileTracingIncludes`로 이 라우트에 필요한 패키지 디렉터리(`@napi-rs/canvas`, `onnxruntime-node`, `sharp`, `kordoc`)를 명시적으로 강제 포함시켰습니다. 각 glob 패턴은 로컬 pnpm 가상 스토어(`node_modules/.pnpm/...`)에서 실제 파일과 매칭되는지 확인 후 반영했고, 매칭 안 되는 패턴(플랫폼 심볼릭 링크 경로 등)은 제외했습니다.

## 스크린샷/동영상 📸

없음

## 관련 이슈 🚨

#451, #468의 후속 수정

## 리뷰 요청사항 👀

- glob 패턴이 Vercel의 Linux 빌드 환경에서도 올바르게 매칭되는지는 실제 배포 후 확인이 필요합니다. 로컬(macOS)에서는 `@napi-rs+canvas-darwin-arm64`만 설치돼 있어 Linux 바이너리(`@napi-rs+canvas-linux-x64-gnu` 등)가 실제로 포함되는지는 로컬에서 검증 불가능했습니다 — Vercel 빌드 로그에서 트레이싱된 파일 목록을 확인해주시면 좋겠습니다.
- 이 PR 머지 후 재배포해도 안 되면, `@napi-rs/canvas`를 `apps/client/package.json`에 직접 의존성으로 선언하는 것도 대안으로 고려할 수 있습니다(트레이싱이 optional require보다 직접 의존성을 더 안정적으로 잡는 경우가 많음).

---

## 추가 수정 (961MB 함수 크기 초과)

위 커밋을 머지 전 재배포했더니 빌드는 성공했지만 배포 단계에서 막혔습니다.

```
The Vercel Function "api/school-record-ocr" is 961.37mb uncompressed which
exceeds the maximum uncompressed size limit of 250mb.
```

원인은 위에서 추가한 `outputFileTracingIncludes` 와일드카드가 너무 넓었던 것입니다.

- `@napi-rs/canvas*`가 darwin/android/win32 등 필요 없는 플랫폼 패키지 10종을 전부 매칭
- `onnxruntime-node*`는 더 심각했습니다 — `@huggingface/transformers`가 `onnxruntime-node`를
  `dependencies: 1.24.3`과 `optionalDependencies: 1.27.0`으로 동시에 선언해서 pnpm 가상
  스토어에 두 버전이 공존하는데, 각 버전 `bin/` 안에 linux/darwin/win32(DirectML.dll 포함)
  바이너리가 전부 들어 있어 버전당 200MB 이상이었습니다.

Vercel 서버리스 런타임은 glibc 기반 Linux x64뿐이므로, 실제로 필요한
`linux-x64-gnu` 바이너리(및 onnxruntime-node의 `bin/napi-v6/linux/x64`)만
남기도록 패턴을 좁혔습니다. 로컬에서 각 패턴이 실제 파일과 매칭되는지 재확인했고,
예상 크기는 약 110~120MB(canvas ~25MB + onnxruntime-node 두 버전 linux/x64 ~71MB
+ sharp/kordoc 나머지)로 250MB 한도 내입니다.


---

## 추가 수정 2 (여전히 599MB 초과)

위 수정 후에도 961MB → 599MB로 줄기만 했지 여전히 250MB를 초과했습니다.

원인은 `kordoc*/**/*` 패턴이었습니다. pnpm은 kordoc 패키지 디렉터리 옆에 그
직접/옵셔널 의존성(`onnxruntime-node`, `sharp`, `@huggingface/transformers`,
`@hyzyla/pdfium` 등)을 가리키는 심볼릭 링크를 함께 둡니다. `**/*` 글롭이 이
심볼릭 링크를 그대로 따라 들어가면서, 앞서 linux-x64로 좁혀둔
`onnxruntime-node`를 플랫폼 제한 없이(258MB, darwin/win32 포함) **통째로
다시** 포함시키고 있었습니다.

kordoc 패턴을 kordoc 패키지 디렉터리 자체로만 좁히고, kordoc이 실제로
필요로 하는 옵셔널 의존성 중 순수 JS/WASM이라 플랫폼 분기가 없는
`@huggingface/transformers`(13MB), `@hyzyla/pdfium`(11MB)는 별도 패턴으로
명시 포함시켰습니다. 예상 합산 크기는 약 150MB로 250MB 한도 내입니다.


---

## 추가 수정 3 (621MB, VERCEL_ANALYZE_BUILD_OUTPUT 리포트로 실측)

`VERCEL_ANALYZE_BUILD_OUTPUT=1` 리포트로 처음으로 추측 없이 정확한 크기
breakdown을 확인했습니다.

```
• @huggingface+transformers@4.2.0: 348.06 MB   ← 최대 원흉
• onnxruntime-node@1.27.0: 36.66 MB
• onnxruntime-node@1.24.3: 33.93 MB            ← 중복
• @napi-rs+canvas@0.1.100: 31.97 MB            ← 베이스인데 왜 32MB?
• @napi-rs+canvas-linux-x64-gnu@0.1.100: 31.85 MB
• sharp@0.35.3: 21.05 MB
• @img+sharp-linux-x64@0.35.3: 17.77 MB
• @img+sharp-libvips-linux-x64@1.3.2: 17.36 MB
• sharp@0.34.5: 16.99 MB                       ← 중복
• @img+sharp-linux-x64@0.34.5: 16.29 MB        ← 중복
```

kordoc 소스(`dist/formula-*.cjs`)를 직접 읽어 확인했습니다:
`@huggingface/transformers`와 `@hyzyla/pdfium`은 kordoc의 `formulaOcr`
옵션(수식 인식 전용, 기본 `false`)에서만 `tryImport`로 로드됩니다. 우리
라우트는 `parse(buffer, { ocr: true, tables: true })`만 호출하고
`formulaOcr`을 켜지 않으므로 **애초에 필요 없는 의존성**이었습니다.
`@huggingface/transformers` 옆에는 심볼릭 링크로 `onnxruntime-web`,
별도 버전의 `onnxruntime-node`(1.24.3)·`sharp`(0.34.5)까지 딸려 있어서
348MB로 부풀어 있었던 것입니다.

`@napi-rs/canvas` 베이스 패키지가 32MB였던 것도 같은 패턴 — 자기 옆
`@napi-rs/canvas-darwin-arm64` 심볼릭 링크를 글롭이 따라 들어간 것이었습니다.

**수정**:
- `@huggingface/transformers`, `@hyzyla/pdfium`을 `serverExternalPackages`와
  `outputFileTracingIncludes`에서 완전히 제거
- 실제 이미지 OCR 경로(`dist/image-ocr-*.cjs`)가 쓰는 `onnxruntime-node@1.27.0`,
  `sharp@0.35.3`만 버전을 고정해 포함 (1.24.3/0.34.5는 transformers 전용이었음)
- `@napi-rs/canvas`는 자기 자신 패키지 폴더로만 좁혀 darwin 심볼릭 링크 제외

리포트 실측값 기준으로 재계산하면 약 120MB(canvas 32MB + onnxruntime-node
37MB + sharp+libvips 39MB + kordoc 12MB)로 250MB 한도 내입니다. 이번엔
추측이 아니라 실측 리포트와 kordoc 소스 코드를 직접 읽어 확인한 결과입니다.

`VERCEL_SUPPORT_LARGE_FUNCTIONS=1`은 배포를 막지 않기 위한 임시 조치로
추가했었는데, 이 수정으로 정상 범위에 들어오면 제거해도 됩니다.


---

## 리뷰 반영 (turbo.json 환경변수 선언)

@codex 리뷰 확인 — 함수 크기는 176MB로 250MB 제한 이내임을 확인해주셨습니다.
지적해주신 대로 `turbo.json`에 OCR 라우트가 쓰는 환경변수(`AWS_REGION`,
`AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
`KORDOC_MODEL_CACHE`)를 선언했습니다. 다른 워크스페이스 패키지의 빌드
캐시까지 무효화되지 않도록 공통 `build` task가 아니라 `client#build`로
범위를 한정했습니다.

이제 재배포 후 실제 stage OCR 요청에서 환경 변수 주입과 `rawText` 반환을
확인하면 됩니다.
