### PR TITLE
[oneseo] 자유학기제 원서 1학년 1학기 성적 표시 수정

### DIFF
--- a/packages/ui/src/components/ApplicationPrintPage/ArtsPhysicalTable/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/ArtsPhysicalTable/index.tsx
@@ -8,6 +8,11 @@ const ArtsPhysicalTable = ({ oneseo }: OneseoStatusType) => {
   const artPhysicalScores = getArtPhysicalScores(oneseo);
   const totalArtsPhysicalConvertedScore = oneseo.calculatedScore.artsPhysicalSubjectsScore;
 
+  // 자유학기제로 지정된 학기는 입력 폼이 예체능 성적을 0('없음')으로 채워 저장한다.
+  // 0은 지원자가 직접 고를 수도 있는 값이라 성적 배열만 보고는 구분할 수 없어,
+  // 그 학기가 '없음'으로 표시되고 있었다. freeSemester를 직접 보고 빗금 처리한다.
+  const freeSemester: string | null = oneseo.middleSchoolAchievement.freeSemester || null;
+
   const availableSemesters = semesterArray.filter((semester) => {
     if (oneseo.privacyDetail.graduationType === 'GRADUATE') {
       if (oneseo.middleSchoolAchievement.liberalSystem === '자유학기제') return true;
@@ -77,7 +82,7 @@ const ArtsPhysicalTable = ({ oneseo }: OneseoStatusType) => {
                 ? scoresInSemester.every((s) => s === null || s === undefined)
                 : true;
 
-              if (isSemesterScoreEmpty) {
+              if (isSemesterScoreEmpty || semester === freeSemester) {
                 if (rowIdx === 0) {
                   return (
                     <td

--- a/packages/ui/src/components/ApplicationPrintPage/GeneralSubjectsTable/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/GeneralSubjectsTable/index.tsx
@@ -33,6 +33,31 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
         ? ['1_1', '1_2', '2_1', '2_2', '3_1', '3_2']
         : ['2_1', '2_2', '3_1', '3_2'];
 
+  const getScores = (key: SemesterKey) =>
+    oneseo.middleSchoolAchievement[
+      `achievement${key}` as keyof typeof oneseo.middleSchoolAchievement
+    ] as (number | null)[] | undefined;
+
+  const getConvertedScore = (key: SemesterKey) =>
+    generalSubjectsScoreDetail[`score${key}` as keyof typeof generalSubjectsScoreDetail];
+
+  /**
+   * 이 표(전형성적 입력 확인서)는 환산점이 아니라 "지원자가 실제로 입력한 성취도"를
+   * 보여주는 서식이다. 예전에는 환산점(generalSubjectsScoreDetail)이 없으면 학기를
+   * 통째로 빗금 처리했는데, 그러면 서버가 성취도는 내려주면서 환산점은 아직 못 채우는
+   * 학기(자유학기제가 1-2인 원서의 1학년 1학기)가 입력값까지 같이 가려져 버린다.
+   * 그래서 칸을 채울지 말지는 입력값(middleSchoolAchievement)만 보고 판단한다.
+   */
+  const isSemesterEmpty = (key: SemesterKey) => {
+    if (key === freeSemesterKey) return true;
+
+    const hasAchievement = getScores(key)?.some((score) => score !== null && score !== undefined);
+    if (hasAchievement) return false;
+
+    // 미리보기 응답은 성취도 배열이 비어 오는 경우가 있어 환산점 유무로 한 번 더 확인한다.
+    return !isPreview || getConvertedScore(key) === null || getConvertedScore(key) === undefined;
+  };
+
   return (
     <table className={cn('w-full', 'border', 'border-black', 'text-center')}>
       <thead>
@@ -67,13 +92,7 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
           <tr key={subject}>
             <td className={cn('border', 'border-black')}>{subject}</td>
             {semesters.map((key) => {
-              const detailKey = `score${key}` as keyof typeof generalSubjectsScoreDetail;
-              const scoreDetail = generalSubjectsScoreDetail[detailKey];
-              const scores = oneseo.middleSchoolAchievement[
-                `achievement${key}` as keyof typeof oneseo.middleSchoolAchievement
-              ] as (number | null)[] | undefined;
-
-              if (!scoreDetail || freeSemesterKey === key || (!isPreview && !scores?.length)) {
+              if (isSemesterEmpty(key)) {
                 if (rowIdx === 0) {
                   return (
                     <td
@@ -92,6 +111,8 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
                 return null;
               }
 
+              const scores = getScores(key);
+
               return (
                 <td key={`${key}-${rowIdx}`} className={cn('border', 'border-black')}>
                   {scoreToAlphabet[scores?.[rowIdx] ?? -1] ?? ''}
@@ -103,19 +124,11 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
 
         <tr>
           <td className={cn('border', 'border-black')}>환산점</td>
-          {semesters.map((key) => {
-            const detailKey = `score${key}` as keyof typeof generalSubjectsScoreDetail;
-            const scores = oneseo.middleSchoolAchievement[
-              `achievement${key}` as keyof typeof oneseo.middleSchoolAchievement
-            ] as (number | null)[] | undefined;
-            return (
-              <td key={`${key}-total`} className={cn('border', 'border-black')}>
-                {freeSemesterKey !== key && (isPreview || scores?.length)
-                  ? (generalSubjectsScoreDetail[detailKey] ?? '')
-                  : ''}
-              </td>
-            );
-          })}
+          {semesters.map((key) => (
+            <td key={`${key}-total`} className={cn('border', 'border-black')}>
+              {isSemesterEmpty(key) ? '' : (getConvertedScore(key) ?? '')}
+            </td>
+          ))}
         </tr>
       </tbody>
     </table>

--- a/packages/ui/src/components/ApplicationPrintPage/GeneralSubjectsTable/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/GeneralSubjectsTable/index.tsx
@@ -38,8 +38,17 @@ const GeneralSubjectsTable = ({ oneseo }: OneseoStatusType) => {
       `achievement${key}` as keyof typeof oneseo.middleSchoolAchievement
     ] as (number | null)[] | undefined;
 
-  const getConvertedScore = (key: SemesterKey) =>
-    generalSubjectsScoreDetail[`score${key}` as keyof typeof generalSubjectsScoreDetail];
+  const getConvertedScore = (key: SemesterKey) => {
+    const ownScore =
+      generalSubjectsScoreDetail[`score${key}` as keyof typeof generalSubjectsScoreDetail];
+    if (ownScore !== null && ownScore !== undefined) return ownScore;
+
+    // 자유학기가 1-2인 원서는 1학년 1학기 환산점이 score1_2(자유학기 자리)에 담겨 내려온다.
+    // 자유학기 칸은 어차피 빗금이라 그 값이 묻히므로, 원래 자리인 1-1 칸에 표시한다.
+    if (key === '1_1' && freeSemesterKey === '1_2') return generalSubjectsScoreDetail.score1_2;
+
+    return null;
+  };
 
   /**
    * 이 표(전형성적 입력 확인서)는 환산점이 아니라 "지원자가 실제로 입력한 성취도"를

--- a/packages/ui/src/components/ApplicationPrintPage/OneseoStatus/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/OneseoStatus/index.tsx
@@ -179,8 +179,7 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
               {achievementGradeValues.map((gradeKey) =>
                 !oneseo.middleSchoolAchievement[gradeKey]?.length ||
                 (oneseo.oneseoId !== null &&
-                  generalSubjectsScoreDetail[achievementScoreMap[gradeKey]!] === null) ||
-                gradeKey === 'achievement1_1' ? (
+                  generalSubjectsScoreDetail[achievementScoreMap[gradeKey]!] === null) ? (
                   <td
                     key={gradeKey}
                     className={cn(tdStyle, 'bg-slash', 'bg-contain', 'bg-no-repeat')}

--- a/packages/ui/src/components/ApplicationPrintPage/OneseoStatus/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/OneseoStatus/index.tsx
@@ -1,6 +1,8 @@
 import {
+  AchievementGradeType,
   achievementGradeValues,
   GraduationEnum,
+  LiberalSystemValueEnum,
   MajorEnum,
   OneseoStatusType,
   ScreeningEnum,
@@ -42,6 +44,41 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
     achievement2_2: 'score2_2',
     achievement3_1: 'score3_1',
     achievement3_2: 'score3_2',
+  };
+
+  const isPreview = oneseo.oneseoId === null;
+  const { liberalSystem, freeSemester } = oneseo.middleSchoolAchievement;
+
+  const freeSemesterGradeKey =
+    liberalSystem === LiberalSystemValueEnum.FREE_SEMESTER && freeSemester
+      ? (`achievement${freeSemester.replace('-', '_')}` as AchievementGradeType)
+      : null;
+
+  /**
+   * 자유학기로 지정된 학기에는 애초에 성적이 존재할 수 없다. 그런데 자유학기가 1-2인
+   * 원서는 1학년 1학기 환산점이 score1_2(자유학기 자리)에 담겨 내려온다. 그대로 그리면
+   * "1학년 2학기 성적이 있다"는 오해를 부르므로, 그 값은 원래 자리인 1-1 칸에 표시하고
+   * 자유학기 칸은 빗금으로 비운다. 서버가 score1_1을 채워 주면 그 값이 우선한다.
+   */
+  const getConvertedScore = (gradeKey: AchievementGradeType) => {
+    const ownScore = generalSubjectsScoreDetail[achievementScoreMap[gradeKey]!];
+    if (ownScore !== null && ownScore !== undefined) return ownScore;
+
+    if (gradeKey === 'achievement1_1' && freeSemesterGradeKey === 'achievement1_2') {
+      return generalSubjectsScoreDetail.score1_2;
+    }
+
+    return null;
+  };
+
+  const isSemesterEmpty = (gradeKey: AchievementGradeType) => {
+    if (gradeKey === freeSemesterGradeKey) return true;
+
+    const score = getConvertedScore(gradeKey);
+    if (score === null || score === undefined) return true;
+
+    // 미리보기는 환산점만 먼저 내려오는 경우가 있어 입력값 유무로 한 번 더 확인한다.
+    return isPreview && !oneseo.middleSchoolAchievement[gradeKey]?.length;
   };
 
   return (
@@ -177,16 +214,14 @@ const OneseoStatus = ({ oneseo }: OneseoStatusType) => {
           ) : (
             <>
               {achievementGradeValues.map((gradeKey) =>
-                !oneseo.middleSchoolAchievement[gradeKey]?.length ||
-                (oneseo.oneseoId !== null &&
-                  generalSubjectsScoreDetail[achievementScoreMap[gradeKey]!] === null) ? (
+                isSemesterEmpty(gradeKey) ? (
                   <td
                     key={gradeKey}
                     className={cn(tdStyle, 'bg-slash', 'bg-contain', 'bg-no-repeat')}
                   />
                 ) : (
                   <td key={gradeKey} className={cn(tdStyle)}>
-                    {generalSubjectsScoreDetail[achievementScoreMap[gradeKey]!]}
+                    {getConvertedScore(gradeKey)}
                   </td>
                 ),
               )}


### PR DESCRIPTION
## 개요 💡

백엔드가 자유학기제가 `1-2`인 원서의 조회 응답에 1학년 1학기 성적을 채워 내려주도록 변경되었습니다. 프론트에는 "1학년 1학기 성적은 항상 없다"는 전제로 작성된 로직이 남아 있어, 성적이 내려와도 화면에 표시되지 않거나 다른 학기 칸에 표시되는 문제가 있어 이를 수정하였습니다.

## 작업내용 ⌨️

**`OneseoStatus` (교과 성적 요약표)**

- `gradeKey === 'achievement1_1'`이면 데이터와 무관하게 항상 빗금 처리하던 하드코딩을 제거하였습니다.
- 자유학기 여부를 전혀 보지 않아 자유학기 칸에도 환산점이 그대로 찍히던 문제를 수정하였습니다. `freeSemester`에 해당하는 학기는 항상 빗금 처리됩니다.

**`GeneralSubjectsTable` (확인서 일반교과 표)**

- 학기 칸을 채울지 여부를 환산점(`generalSubjectsScoreDetail`) 유무로 판단하고 있었습니다. 이 서식은 환산점이 아니라 지원자가 실제로 입력한 성취도를 증명하는 문서인데, 판단 근거가 환산점에 묶여 있어 서버가 성취도만 내려주고 환산점을 채우지 못한 학기는 입력값까지 함께 가려졌습니다. 판단 근거를 `middleSchoolAchievement`로 옮겼습니다.
- 기존 `!scoreDetail` 조건 때문에 환산점이 `0`인 학기도 빗금 처리되던 문제가 함께 해소되었습니다.

**`ArtsPhysicalTable` (확인서 체육예술교과 표)**

- 자유학기로 지정된 학기는 입력 폼이 예체능 성적을 `0`으로 채워 저장하는데, `0`은 지원자가 직접 선택할 수 있는 `없음` 값이라 배열만으로는 구분되지 않아 해당 학기가 `없음`으로 표시되고 있었습니다. `freeSemester`를 직접 확인해 빗금 처리하도록 수정하였습니다.

**환산점 위치 보정 (`OneseoStatus`, `GeneralSubjectsTable`)**

- 자유학기가 `1-2`인 원서에서 1학년 1학기 환산점이 `score1_2`, 즉 자유학기 자리에 담겨 내려오고 있었습니다. 자유학기에는 성적이 존재할 수 없으므로 해당 값은 1학년 1학기 값으로 판단하고 `1-1` 칸에 표시하도록 하였습니다.
- `score1_1`이 채워져 내려오면 그 값이 우선하므로, 백엔드가 제자리에 담아 주도록 수정되어도 이중 표시나 되돌림 없이 그대로 동작합니다.

## 관련 이슈 🚨

closes #460

## 리뷰 요청사항 👀

- 환산점 위치 보정은 "자유학기 자리에 담겨 온 환산점은 1학년 1학기 값"이라는 전제 위에 있습니다. 조회 응답의 `calculatedScore.generalSubjectsScoreDetail`에서 `score1_1`과 `score1_2` 중 어느 쪽에 값이 담겨 오는지 확인해 주시면 좋겠습니다. `score1_1`에 정상적으로 담겨 온다면 이 보정은 동작하지 않고 넘어갑니다.
- 서버가 값을 제자리에 담아 주도록 수정하는 편이 근본적인 해결이라고 판단해, 백엔드에도 함께 공유가 필요해 보입니다.

https://claude.ai/code/session_01NeYRkuQNs9DSntbSZYRxgr
