### PR TITLE
[school-record-ocr] OCR 처리 소요 시간 안내 문구 추가

### DIFF
--- a/packages/ui/src/components/SchoolRecordUploader/index.tsx
+++ b/packages/ui/src/components/SchoolRecordUploader/index.tsx
@@ -220,8 +220,9 @@ const SchoolRecordUploader = ({
         <div className={cn('flex', 'flex-col', 'gap-0.5')}>
           <p className={cn('text-xs', 'text-blue-700')}>{STATUS_TEXT[status]}</p>
           <p className={cn('text-xs', 'text-slate-500')}>
-            파일 용량과 페이지 수에 따라 약 5분 정도 걸릴 수 있어요. 창을 닫지 말고 잠시만 기다려
-            주세요.
+            {status === 'processing'
+              ? '파일 용량과 페이지 수에 따라 약 5분 정도 걸릴 수 있어요. 창을 닫지 말고 잠시만 기다려 주세요.'
+              : '창을 닫지 말고 잠시만 기다려 주세요.'}
           </p>
         </div>
       )}

--- a/packages/ui/src/components/SchoolRecordUploader/index.tsx
+++ b/packages/ui/src/components/SchoolRecordUploader/index.tsx
@@ -216,7 +216,15 @@ const SchoolRecordUploader = ({
         </div>
       </div>
 
-      {isProcessing && <p className={cn('text-xs', 'text-blue-700')}>{STATUS_TEXT[status]}</p>}
+      {isProcessing && (
+        <div className={cn('flex', 'flex-col', 'gap-0.5')}>
+          <p className={cn('text-xs', 'text-blue-700')}>{STATUS_TEXT[status]}</p>
+          <p className={cn('text-xs', 'text-slate-500')}>
+            파일 용량과 페이지 수에 따라 약 5분 정도 걸릴 수 있어요. 창을 닫지 말고 잠시만 기다려
+            주세요.
+          </p>
+        </div>
+      )}
 
       {status === 'error' && errorMessage && (
         <p className={cn('text-xs', 'text-red-600')}>{errorMessage}</p>


### PR DESCRIPTION
## 개요 💡

`OCR` 기반 생기부 자동 입력 기능은 파일 용량과 페이지 수에 따라 처리 시간이 길어질 수 있으나, 처리 중임을 알리는 문구만 있고 소요 시간에 대한 안내가 없어 사용자가 멈춘 것으로 오인할 수 있었습니다.

## 작업내용 ⌨️

- `SchoolRecordUploader` 컴포넌트에서 `isProcessing` 상태일 때 노출되는 안내 영역에 소요 시간 안내 문구를 추가하였습니다.
- 기존 상태 텍스트(`STATUS_TEXT`) 아래에 "파일 용량과 페이지 수에 따라 약 5분 정도 걸릴 수 있어요. 창을 닫지 말고 잠시만 기다려 주세요." 문구를 노출하도록 수정하였습니다.

## 스크린샷/동영상 📸

<img width="1512" height="911" alt="스크린샷 2026-09-06 오후 5 16 06" src="https://github.com/user-attachments/assets/567a72f9-42d9-459d-b762-b4a7506ec925" />


## 관련 이슈 🚨

closes #472

## 리뷰 요청사항 👀

안내 문구의 표현("약 5분 정도")이 실제 처리 시간 체감과 맞는지 확인 부탁드립니다.
