### PR TITLE
[oneseo] 인적사항 표 보호자 행 높이 불균등 수정

### DIFF
--- a/packages/ui/src/components/ApplicationPrintPage/PersonalInfoTable/index.tsx
+++ b/packages/ui/src/components/ApplicationPrintPage/PersonalInfoTable/index.tsx
@@ -5,6 +5,10 @@ import FormColgroup from '../FormColgroup';
 
 const thStyle = 'border border-black bg-[#e9e9e9] ';
 const tdStyle = 'border border-black ';
+// 증명사진(3cm x 4cm, 151.18110236px) 셀이 rowSpan={5}로 걸쳐 있는데, 이 높이를 각 행에
+// 명시적으로 나눠주지 않으면 브라우저가 5개 행에 균등하게 분배하지 않고 특정 행 하나에
+// 몰아서 그 행만 비정상적으로 길어지는 테이블 레이아웃 버그가 발생합니다.
+const rowHeight = 'h-[30.23622047px]';
 
 type Props = OneseoStatusType;
 
@@ -15,7 +19,7 @@ const PersonalInfoTable = ({ oneseo }: Props) => {
     <table className={cn('w-full', 'border-collapse', 'text-center', 'text-[1.2vh]')}>
       <FormColgroup />
       <thead>
-        <tr>
+        <tr className={rowHeight}>
           <td className={cn(thStyle, 'border-l-0')} rowSpan={5}>
             인적사항
           </td>
@@ -44,21 +48,21 @@ const PersonalInfoTable = ({ oneseo }: Props) => {
           </td>
         </tr>
 
-        <tr>
+        <tr className={rowHeight}>
           <td className={cn(thStyle)}>주 소</td>
           <td className={cn(tdStyle)} colSpan={8}>
             {oneseo.privacyDetail.address} {oneseo.privacyDetail.detailAddress}
           </td>
         </tr>
 
-        <tr>
+        <tr className={rowHeight}>
           <td className={cn(thStyle)}>핸드폰</td>
           <td className={cn(tdStyle)} colSpan={8}>
             {oneseo.privacyDetail.phoneNumber}
           </td>
         </tr>
 
-        <tr>
+        <tr className={rowHeight}>
           <td className={cn(thStyle, 'leading-tight')} rowSpan={2}>
             보호자
           </td>
@@ -66,10 +70,8 @@ const PersonalInfoTable = ({ oneseo }: Props) => {
           <td className={cn(thStyle)}>성 명</td>
           <td className={cn(tdStyle)}>{oneseo.privacyDetail.guardianName}</td>
 
-          <td className={cn(thStyle, 'leading-none')} colSpan={2}>
-            지원자와의
-            <br />
-            관계
+          <td className={cn(thStyle, 'leading-none', 'whitespace-nowrap')} colSpan={2}>
+            지원자와의 관계
           </td>
 
           <td className={cn(tdStyle)} colSpan={5}>
@@ -77,7 +79,7 @@ const PersonalInfoTable = ({ oneseo }: Props) => {
           </td>
         </tr>
 
-        <tr>
+        <tr className={rowHeight}>
           <td className={cn(thStyle)}>핸드폰</td>
           <td className={cn(tdStyle)} colSpan={8}>
             {oneseo.privacyDetail.guardianPhoneNumber}


### PR DESCRIPTION
## 개요 💡


원서 미리보기 출력 화면의 인적사항 표에서 `보호자` 영역의 `성명 / 지원자와의 관계` 행만 다른 행보다 눈에 띄게 길게 렌더링되는 문제를 수정하였습니다. (관련 이슈: #474)

## 작업내용 ⌨️



- 원인을 분석한 결과, 텍스트 줄바꿈 문제가 아니라 증명사진 셀(`rowSpan={5}`, `h-[151px]`)의 높이를 5개 행에 분배하는 과정에서 브라우저가 균등하게 나누지 않고 `보호자` 그룹의 첫 번째 행에만 대부분을 몰아주는 테이블 레이아웃 문제였습니다.
- `PersonalInfoTable`의 각 `<tr>`에 `151.18110236px ÷ 5 = 30.23622047px`를 명시적으로 지정하여, 사진 셀이 필요로 하는 높이가 5개 행에 고르게 분배되도록 수정하였습니다.
- 표 전체 높이는 기존과 동일하게 유지되며, 문제였던 행만 다른 행과 비슷한 높이로 줄어듭니다.
- 부수적으로 `지원자와의 관계` 텍스트의 불필요한 강제 줄바꿈(`<br />`)을 제거하고 한 줄로 정리하였습니다.

## 스크린샷/동영상 📸

<img width="1512" height="911" alt="스크린샷 2026-09-06 오후 5 54 56" src="https://github.com/user-attachments/assets/947a0985-3f75-45ef-a9c4-3e09aa70a7e1" />


수정 전: `성명 / 지원자와의 관계` 행이 다른 행 대비 약 4배 높게 렌더링됨
수정 후: 모든 행이 균등한 높이로 렌더링됨

## 관련 이슈 🚨



closes #474

