### PR TITLE
[oneseo] 자유학기 미선택 시 안내 문구 및 토글 강조 추가

### DIFF
--- a/packages/ui/src/components/form/FreeSemesterForm/index.tsx
+++ b/packages/ui/src/components/form/FreeSemesterForm/index.tsx
@@ -184,7 +184,7 @@ const FreeSemesterForm = ({
                 <button
                   className={cn([
                     ...freeSemesterButtonStyle,
-                    showError && errors.freeSemester && !isGraduate && '!border-red-600',
+                    showError && !freeSemester && '!border-red-600',
                   ])}
                   type="button"
                   onClick={() => {
@@ -200,6 +200,11 @@ const FreeSemesterForm = ({
           ))}
         </div>
       </div>
+      {showError && !freeSemester && (
+        <p className={cn('mt-2', 'text-xs', 'text-red-600')}>
+          자유학기에 해당하는 학기를 선택(on)해야 제출할 수 있어요.
+        </p>
+      )}
       {subjectArray.map((subject, idx) => {
         const dynamicIndex = idx - defaultSubjectLength;
 


### PR DESCRIPTION
## 개요 💡

성적 등록 화면에서 `자유학기제`를 선택한 뒤, 6개 학기 중 실제 자유학기에 해당하는 학기를 토글로 활성화(`on`)하지 않으면 다음 단계로 넘어가지 못했습니다. 이때 아무런 안내가 없어 사용자가 왜 제출이 막히는지 알기 어려웠던 문제를 해결하였습니다.

## 작업내용 ⌨️

`FreeSemesterForm` (`packages/ui/src/components/form/FreeSemesterForm/index.tsx`)

- 제출을 시도했지만(`showError`) 자유학기 토글을 하나도 활성화하지 않은 경우, 안내 문구(`자유학기에 해당하는 학기를 선택(on)해야 제출할 수 있어요.`)를 토글 행 아래에 표시하도록 추가하였습니다.
- 같은 조건에서 모든 `off` 토글 버튼의 테두리를 빨간색으로 강조하도록 수정하였습니다.
- 기존에는 재학생(`!isGraduate`)에게만 토글 강조가 적용되던 조건을 제거하여, 재학생/졸업자 구분 없이 동일하게 동작하도록 정리하였습니다.

## 스크린샷/동영상 📸

<img width="808" height="200" alt="image" src="https://github.com/user-attachments/assets/eb061e5e-b3d4-458a-972b-102061b8454d" />


## 관련 이슈 🚨

closes #476

## 리뷰 요청사항 👀

- 안내 문구 위치와 문구가 실제 UX상 자연스러운지 확인 부탁드립니다.
