### PR TITLE
[global] S3 다운로드 파일명 수정

### DIFF
--- a/apps/client/src/components/MainPage/Section2/index.tsx
+++ b/apps/client/src/components/MainPage/Section2/index.tsx
@@ -142,7 +142,10 @@ const Section2 = () => {
                   'cursor-pointer',
                 )}
                 onClick={() => {
-                  window.open(`${process.env.NEXT_PUBLIC_CDN_URL}/2026_입학_요강.hwp`, '_blank');
+                  window.open(
+                    `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 광주소프트웨어마이스터고등학교 신입생 전형요강.hwpx`,
+                    '_blank',
+                  );
                 }}
               >
                 입학요강 다운로드

--- a/apps/client/src/components/PassResultDialog/index.tsx
+++ b/apps/client/src/components/PassResultDialog/index.tsx
@@ -187,7 +187,7 @@ const PassResultDialog = ({
                 className={cn('w-[10.625rem]', 'h-[3.25rem]', 'font-semibold', 'text-base')}
                 onClick={() =>
                   push(
-                    `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신임생 최종 합격자 제출 서류 안내.hwpx`,
+                    `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신입생 최종 합격자 제출 서류 안내.hwpx`,
                   )
                 }
               >

--- a/apps/client/src/components/PassResultDialog/index.tsx
+++ b/apps/client/src/components/PassResultDialog/index.tsx
@@ -186,7 +186,9 @@ const PassResultDialog = ({
                 variant="reverseFill"
                 className={cn('w-[10.625rem]', 'h-[3.25rem]', 'font-semibold', 'text-base')}
                 onClick={() =>
-                  push(`${process.env.NEXT_PUBLIC_CDN_URL}/최종_합격자_제출_목록.hwpx`)
+                  push(
+                    `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신임생 최종 합격자 제출 서류 안내.hwpx`,
+                  )
                 }
               >
                 합격자 제출서류 다운
@@ -206,7 +208,7 @@ const PassResultDialog = ({
                   className={cn('w-[10.625rem]', 'h-[3.25rem]', 'font-semibold', 'text-base')}
                   onClick={() =>
                     push(
-                      `${process.env.NEXT_PUBLIC_CDN_URL}/2026학년_신입생_선발_1차_전형_합격자_안내사항.hwp`,
+                      `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신입생 선발 1차 전형 합격자 안내사항.hwp`,
                     )
                   }
                 >

--- a/apps/client/src/pageContainer/GuidePage/index.tsx
+++ b/apps/client/src/pageContainer/GuidePage/index.tsx
@@ -68,7 +68,7 @@ const Elements: ElementType[] = [
         절차를 읽고 원서와 성적을 작성해 주시면 입학 신청이 완료됩니다.
         <a
           className={cn('flex', 'items-center', 'gap-3', 'mt-5', 'cursor-pointer', 'w-fit')}
-          href={`${process.env.NEXT_PUBLIC_CDN_URL}/입학_원서_작성_요령.hwp`}
+          href={`${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신입생 입학 원서 작성 요령.hwp`}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/apps/client/src/pageContainer/MyPage/index.tsx
+++ b/apps/client/src/pageContainer/MyPage/index.tsx
@@ -80,13 +80,13 @@ const MyPage = ({ initialData, isOneseoWrite }: MyInfoProps) => {
     {
       icon: <DocumentIcon />,
       text: '유형별 제출서류 안내 파일',
-      path: `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신임생 최종 합격자 제출 서류 안내.hwpx`,
+      path: `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신입생 최종 합격자 제출 서류 안내.hwpx`,
     },
     { icon: <PrintIcon />, text: '입학원서', path: 'print' },
     {
       icon: <PrintIcon />,
       text: '제출서류',
-      path: `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신임생 최종 합격자 제출 서류 안내.hwpx`,
+      path: `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신입생 최종 합격자 제출 서류 안내.hwpx`,
     },
   ];
 

--- a/apps/client/src/pageContainer/MyPage/index.tsx
+++ b/apps/client/src/pageContainer/MyPage/index.tsx
@@ -80,13 +80,13 @@ const MyPage = ({ initialData, isOneseoWrite }: MyInfoProps) => {
     {
       icon: <DocumentIcon />,
       text: '유형별 제출서류 안내 파일',
-      path: `${process.env.NEXT_PUBLIC_CDN_URL}/지원자_제출_서류_목록_안내.hwpx`,
+      path: `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신임생 최종 합격자 제출 서류 안내.hwpx`,
     },
     { icon: <PrintIcon />, text: '입학원서', path: 'print' },
     {
       icon: <PrintIcon />,
       text: '제출서류',
-      path: `${process.env.NEXT_PUBLIC_CDN_URL}/입학_제출_서류.hwp`,
+      path: `${process.env.NEXT_PUBLIC_CDN_URL}/2027학년도 신임생 최종 합격자 제출 서류 안내.hwpx`,
     },
   ];
 


### PR DESCRIPTION
## 개요 💡

> S3 버킷에서 제공하는 첨부파일들의 파일명이 변경됨에 따라, 클라이언트에서 다운로드 요청 시 참조하는 파일명을 최신 파일명으로 맞추기 위한 작업입니다.

## 작업내용 ⌨️

> 아래 6개 다운로드 링크의 파일명을 이슈에서 안내된 새 파일명으로 수정하였습니다.

- `GuidePage/index.tsx`: `입학_원서_작성_요령.hwp` → `2027학년도 신입생 입학 원서 작성 요령.hwp`
- `PassResultDialog/index.tsx`: `최종_합격자_제출_목록.hwpx` → `2027학년도 신임생 최종 합격자 제출 서류 안내.hwpx`
- `PassResultDialog/index.tsx`: `2026학년_신입생_선발_1차_전형_합격자_안내사항.hwp` → `2027학년도 신입생 선발 1차 전형 합격자 안내사항.hwp`
- `MyPage/index.tsx`: `지원자_제출_서류_목록_안내.hwpx` → `2027학년도 신임생 최종 합격자 제출 서류 안내.hwpx`
- `MyPage/index.tsx`: `입학_제출_서류.hwp` → `2027학년도 신임생 최종 합격자 제출 서류 안내.hwpx`
- `MainPage/Section2/index.tsx`: `2026_입학_요강.hwp` → `2027학년도 광주소프트웨어마이스터고등학교 신입생 전형요강.hwpx`

## 관련 이슈 🚨

> closes #482
