### PR TITLE
[oneseo] 원서 임시저장 400 에러 수정

### DIFF
--- a/packages/ui/src/components/StepWrapper/index.tsx
+++ b/packages/ui/src/components/StepWrapper/index.tsx
@@ -324,33 +324,36 @@ const StepWrapper = ({ data, step, info, memberId, type, isModifyApproved }: Ste
       schoolTeacherName: schoolTeacherName || undefined,
       schoolTeacherPhoneNumber: schoolTeacherPhoneNumber || undefined,
 
-      // step 4
-      middleSchoolAchievement: isGED
-        ? {
-            gedAvgScore: gedAvgScore!,
-          }
-        : {
-            liberalSystem: liberalSystem,
-            achievement1_1: achievement1_1!,
-            achievement1_2: achievement1_2!,
-            achievement2_1: achievement2_1!,
-            achievement2_2: achievement2_2!,
-            achievement3_1: achievement3_1!,
-            achievement3_2: achievement3_2!,
-            newSubjects: newSubjects,
-            artsPhysicalAchievement: artsPhysicalAchievement!,
-            absentDays: absentDays!,
-            attendanceDays: attendanceDays!,
-            volunteerTime: volunteerTime!,
-            freeSemester:
-              liberalSystem === LiberalSystemValueEnum.FREE_GRADE
-                ? null
-                : graduationType === GraduationTypeValueEnum.GRADUATE
-                  ? (freeSemester ?? '')
-                  : freeSemester,
-            generalSubjects: [...GENERAL_SUBJECTS],
-            artsPhysicalSubjects: [...ARTS_PHYSICAL_SUBJECTS],
-          },
+      // step 4 — GED 분기({ gedAvgScore }만 담은 객체)는 점수가 실제로 입력된
+      // 뒤에만 쓴다. 점수가 없는 상태로는 이 형태({})도, 키 생략도 서버가
+      // 거부하므로(각각 400/500), 점수 입력 전에는 다른 전형과 동일한 전체
+      // 객체를 보낸다 — step1~3 임시저장에서 정상 동작이 확인된 형태다.
+      middleSchoolAchievement:
+        isGED && gedAvgScore != null
+          ? {
+              gedAvgScore: gedAvgScore,
+            }
+          : {
+              liberalSystem: liberalSystem,
+              achievement1_1: achievement1_1!,
+              achievement1_2: achievement1_2!,
+              achievement2_1: achievement2_1!,
+              achievement2_2: achievement2_2!,
+              achievement3_1: achievement3_1!,
+              achievement3_2: achievement3_2!,
+              newSubjects: newSubjects,
+              artsPhysicalAchievement: artsPhysicalAchievement!,
+              absentDays: absentDays!,
+              attendanceDays: attendanceDays!,
+              volunteerTime: volunteerTime!,
+              // freeSemester는 서버 enum이라 ''를 허용하지 않는다(스웨거 확인).
+              // 과거엔 졸업(GRADUATE) 전형만 ''로 보냈는데, 이는 서버가 거부하는
+              // 값이라 항상 400을 유발했다 — null로 통일한다.
+              freeSemester:
+                liberalSystem === LiberalSystemValueEnum.FREE_GRADE ? null : freeSemester,
+              generalSubjects: [...GENERAL_SUBJECTS],
+              artsPhysicalSubjects: [...ARTS_PHYSICAL_SUBJECTS],
+            },
 
       step: isTemp ? Number(step) : undefined,
     };


### PR DESCRIPTION
## 개요 💡

검정고시(`GED`) 지원자가 원서 작성 중 임시저장을 하면 서버가 400을 반환하여 저장에 실패하는 문제를 수정하였습니다. 자동 임시저장은 단계 이동 시에도 동작하기 때문에, 검정고시 지원자는 step2에서 다음 단계로 넘어갈 때마다 실패를 겪는 상태였습니다.

## 작업내용 ⌨️

`StepWrapper`의 `getOneseo` 함수에서 임시저장 payload를 구성하는 부분을 수정하였습니다.

**1. 검정고시 분기 조건 수정**

기존에는 `graduationType`이 `GED`이면 즉시 `middleSchoolAchievement`를 `{ gedAvgScore }` 형태로 분기하였습니다. 그러나 `gedAvgScore`는 step4에서 입력하는 값이라 그 이전 단계에서는 `undefined`이고, `JSON.stringify`가 값이 `undefined`인 키를 제거하기 때문에 서버에는 빈 객체 `{}`가 전송되었습니다.

점수가 실제로 입력된 경우에만 검정고시 분기를 타도록 조건을 `isGED && gedAvgScore != null`로 좁혔습니다. 점수 입력 전에는 다른 전형과 동일한 형태의 객체를 전송하며, 이는 다른 전형의 임시저장에서 정상 동작이 확인된 형태입니다.

**2. `freeSemester` 빈 문자열 전송 제거**

졸업(`GRADUATE`) 전형에서 자유학기를 선택하지 않은 경우 `freeSemester`로 빈 문자열을 전송하고 있었습니다. 서버 스펙상 `freeSemester`는 `1-1`부터 `3-2`까지 여섯 개 값만 허용하는 `enum`이므로 빈 문자열은 역직렬화 단계에서 거부됩니다. `GRADUATE` 전용 분기를 제거하고 `null`로 통일하였습니다.

## 리뷰 요청사항 👀

검정고시 지원자가 점수를 입력하기 전까지는 다른 전형과 동일한 payload를 보내므로 `liberalSystem` 등에 의미 없는 기본값이 임시 저장됩니다. 점수 입력 이후의 저장부터는 `{ gedAvgScore }`만 전송되어 덮어써지지만, 서버가 병합 방식으로 동작한다면 값이 남을 수 있습니다. 이 부분에 대한 확인 부탁드립니다.

또한 근본적으로는 임시저장 API가 검정고시 지원자의 점수 입력 전 상태를 허용하지 않는 것으로 보입니다. `middleSchoolAchievement` 키를 생략하면 500, 빈 객체로 전송하면 400이 반환되었습니다. 백엔드에서 이 제약을 완화할 수 있다면 더 근본적인 해결이 될 것 같습니다.
