### PR TITLE
[ocr-lambda] OCR 처리 지연 개선(모델 콜드 다운로드 제거)

### DIFF
--- a/.github/workflows/ocr-lambda-image.yml
+++ b/.github/workflows/ocr-lambda-image.yml
@@ -1,0 +1,19 @@
+name: OCR Lambda Image Build
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'apps/ocr-lambda/**'
+      - 'packages/constants/**'
+
+jobs:
+  build-image:
+    name: Build ocr-lambda Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Build ocr-lambda image (runner stage)
+        run: docker build --platform linux/amd64 --provenance=false --target runner -f apps/ocr-lambda/Dockerfile .

--- a/apps/ocr-lambda/Dockerfile
+++ b/apps/ocr-lambda/Dockerfile
@@ -33,6 +33,15 @@ COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=pruner /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
 RUN pnpm install --frozen-lockfile
+# 텍스트 OCR 모델(PP-OCRv5 korean det+rec, ~18MB)을 빌드 타임에 이미지 안에 구워 넣는다.
+# 안 그러면(런타임 환경변수 KORDOC_MODEL_CACHE가 Lambda의 유일한 쓰기 가능 경로인 /tmp를
+# 가리키던 기존 방식) 실행 환경이 새로 뜰 때(콜드 스타트)마다 이 모델을 인터넷에서 처음부터
+# 다시 받아야 했다 — "OCR 처리 시간이 오래 걸린다"는 문제의 큰 원인 중 하나였다. 이미지 안의
+# 고정 경로에 미리 받아두면 콜드 스타트에서도 다운로드 없이 로컬 파일을 그대로 쓴다. runner
+# 스테이지에서 같은 경로에 이 디렉터리를 그대로 복사하고 같은 환경변수를 지정해야 적용된다 —
+# README 4번(Lambda 함수 생성) 항목의 KORDOC_MODEL_CACHE 값도 함께 바꿔야 한다.
+ENV KORDOC_MODEL_CACHE=/opt/kordoc-models
+RUN pnpm --filter=@repo/ocr-lambda exec kordoc check-ocr-models
 COPY --from=pruner /app/out/full/ .
 RUN pnpm turbo run build --filter=@repo/ocr-lambda
 # pnpm의 node_modules는 상대 심볼릭 링크로 pnpm 가상 저장소(../../../node_modules/.pnpm/...)를
@@ -49,4 +58,8 @@ FROM public.ecr.aws/lambda/nodejs:22 AS runner
 WORKDIR ${LAMBDA_TASK_ROOT}
 COPY --from=installer /app/deploy/dist ./
 COPY --from=installer /app/deploy/node_modules ./node_modules
+# installer 단계에서 미리 받아둔 OCR 모델을 그대로 심는다 — 같은 경로 + 같은 환경변수여야
+# kordoc이 다시 받지 않고 이 파일들을 쓴다(위 installer 단계 주석 참고).
+COPY --from=installer /opt/kordoc-models /opt/kordoc-models
+ENV KORDOC_MODEL_CACHE=/opt/kordoc-models
 CMD ["handler.handler"]

--- a/apps/ocr-lambda/README.md
+++ b/apps/ocr-lambda/README.md
@@ -134,11 +134,24 @@ aws lambda create-function \
   --timeout 120 \
   --memory-size 4096 \
   --region ap-northeast-2 \
-  --environment "Variables={AWS_S3_BUCKET=hellogsm-dev-bucket,KORDOC_MODEL_CACHE=/tmp/kordoc-models,NODE_ENV=production}"
+  --environment "Variables={AWS_S3_BUCKET=hellogsm-dev-bucket,KORDOC_MODEL_CACHE=/opt/kordoc-models,NODE_ENV=production}"
 ```
 
 `NODE_ENV=production`은 필수에 가깝다 — 꺼두면 생기부 원문 내용이 디버그 로그로
 CloudWatch에 그대로 남는다(`achievementTextConverter.ts`의 `kordocDebug` 참고).
+
+`KORDOC_MODEL_CACHE=/opt/kordoc-models`는 `/tmp/kordoc-models`에서 바뀐 값이다 — Dockerfile이
+빌드 타임에 텍스트 OCR 모델(PP-OCRv5 korean, ~18MB)을 이미지 안 `/opt/kordoc-models`에 미리
+받아두도록 바뀌었다. `/tmp`는 Lambda 실행 환경이 새로 뜰 때(콜드 스타트)마다 비워지는 경로라
+그대로 두면 매번 모델을 인터넷에서 다시 받아야 했는데, 이게 "OCR 처리 시간이 오래 걸린다"는
+문제의 원인 중 하나였다. **이미 이 함수를 배포해둔 상태라면** 이미지만 새로 올리는 걸로는
+부족하고, 아래처럼 환경변수도 같이 갱신해야 실제로 적용된다:
+
+```bash
+aws lambda update-function-configuration \
+  --function-name ocr-lambda \
+  --environment "Variables={AWS_S3_BUCKET=hellogsm-dev-bucket,KORDOC_MODEL_CACHE=/opt/kordoc-models,NODE_ENV=production}"
+```
 
 업데이트할 때는:
 

--- a/apps/ocr-lambda/README.md
+++ b/apps/ocr-lambda/README.md
@@ -69,13 +69,20 @@ export ECR_URI=$AWS_ACCOUNT_ID.dkr.ecr.ap-northeast-2.amazonaws.com/ocr-lambda
 aws ecr get-login-password --region ap-northeast-2 | \
   docker login --username AWS --password-stdin $ECR_URI
 
-docker build --platform linux/amd64 -f apps/ocr-lambda/Dockerfile -t $ECR_URI:latest .
+docker build --platform linux/amd64 --provenance=false -f apps/ocr-lambda/Dockerfile -t $ECR_URI:latest .
 docker push $ECR_URI:latest
 ```
 
 `--platform linux/amd64`를 빼먹지 말 것 — Apple Silicon 맥에서 그냥 빌드하면 arm64 이미지가
 되어 Lambda(기본 x86_64) 배포 시 아키텍처 불일치로 실패한다. Graviton(arm64) Lambda로
 가려면 이 플래그와 Lambda 함수의 `--architectures arm64`를 함께 바꿔야 한다.
+
+`--provenance=false`도 빼먹지 말 것 — 요즘 Docker CLI의 `docker build`는 내부적으로 BuildKit/
+buildx를 쓰는데, 기본값으로 SLSA provenance attestation을 함께 만들어서 push한다. 그러면
+ECR의 `:latest`가 실제 이미지 하나가 아니라 "실제 이미지 + attestation" 두 매니페스트를 묶은
+OCI 이미지 인덱스(manifest list)가 되는데, AWS Lambda는 이런 멀티 매니페스트 형식을 지원하지
+않아 나중에 `update-function-code`가 매니페스트 타입 에러로 실패한다. `--provenance=false`를
+주면 attestation 없이 단일 이미지 매니페스트만 만들어 push한다.
 
 ### 3. IAM — Lambda 실행 역할
 
@@ -151,7 +158,7 @@ CloudWatch에 그대로 남는다(`achievementTextConverter.ts`의 `kordocDebug`
 업데이트할 때는:
 
 ```bash
-docker build --platform linux/amd64 -f apps/ocr-lambda/Dockerfile -t $ECR_URI:latest .
+docker build --platform linux/amd64 --provenance=false -f apps/ocr-lambda/Dockerfile -t $ECR_URI:latest .
 docker push $ECR_URI:latest
 aws lambda update-function-code \
   --function-name ocr-lambda \

--- a/apps/ocr-lambda/README.md
+++ b/apps/ocr-lambda/README.md
@@ -145,13 +145,8 @@ CloudWatch에 그대로 남는다(`achievementTextConverter.ts`의 `kordocDebug`
 받아두도록 바뀌었다. `/tmp`는 Lambda 실행 환경이 새로 뜰 때(콜드 스타트)마다 비워지는 경로라
 그대로 두면 매번 모델을 인터넷에서 다시 받아야 했는데, 이게 "OCR 처리 시간이 오래 걸린다"는
 문제의 원인 중 하나였다. **이미 이 함수를 배포해둔 상태라면** 이미지만 새로 올리는 걸로는
-부족하고, 아래처럼 환경변수도 같이 갱신해야 실제로 적용된다:
-
-```bash
-aws lambda update-function-configuration \
-  --function-name ocr-lambda \
-  --environment "Variables={AWS_S3_BUCKET=hellogsm-dev-bucket,KORDOC_MODEL_CACHE=/opt/kordoc-models,NODE_ENV=production}"
-```
+부족하고 환경변수도 같이 갱신해야 실제로 적용되는데, 아래 "업데이트할 때는" 순서를 반드시
+지켜야 한다.
 
 업데이트할 때는:
 
@@ -161,6 +156,30 @@ docker push $ECR_URI:latest
 aws lambda update-function-code \
   --function-name ocr-lambda \
   --image-uri $ECR_URI:latest
+```
+
+**반드시 이미지 코드 갱신이 끝난 뒤에 환경변수를 바꿔야 한다** — 순서를 바꿔서 이미지보다
+먼저 `KORDOC_MODEL_CACHE`를 `/opt/kordoc-models`로 바꾸면, 아직 그 경로가 없는 기존(구)
+이미지가 그 사이에 호출될 경우 모델 캐시 디렉터리를 만들지 못해(Lambda는 `/tmp` 밖이 읽기
+전용이다) OCR이 일시적으로 실패한다. `update-function-code`는 비동기이므로 아래처럼
+`LastUpdateStatus`가 `Successful`이 될 때까지 기다린 뒤에 진행한다:
+
+```bash
+aws lambda wait function-updated --function-name ocr-lambda
+```
+
+환경변수를 갱신할 때도 `--environment`는 기존 `Variables` 맵 전체를 그 값으로 **교체**한다 —
+여기 예시에 없는 변수가 실제 함수에 이미 설정되어 있다면 그대로 날아간다. 먼저 현재 값을
+읽어서 필요한 값만 바꾼 전체 맵을 다시 넣어야 한다:
+
+```bash
+aws lambda get-function-configuration \
+  --function-name ocr-lambda \
+  --query "Environment.Variables"
+# 위 출력을 기준으로 KORDOC_MODEL_CACHE만 바꾼 전체 Variables 맵을 아래에 채워 넣는다
+aws lambda update-function-configuration \
+  --function-name ocr-lambda \
+  --environment "Variables={AWS_S3_BUCKET=hellogsm-dev-bucket,KORDOC_MODEL_CACHE=/opt/kordoc-models,NODE_ENV=production}"
 ```
 
 ### 5. Vercel → Lambda 호출 권한


### PR DESCRIPTION
## 개요 💡

생기부 OCR 처리 시간이 오래 걸리는 문제(#473)의 원인 중 하나를 개선하였습니다.

`apps/ocr-lambda`가 사용하는 한국어 텍스트 OCR 모델(PP-OCRv5, 약 18MB)의 캐시 경로가
`KORDOC_MODEL_CACHE=/tmp/kordoc-models`로 설정되어 있었는데, `/tmp`는 Lambda 실행 환경이
새로 뜰 때(콜드 스타트)마다 비워지는 경로입니다. 트래픽이 뜸한 이 기능 특성상 콜드 스타트가
자주 발생할 수밖에 없고, 그때마다 모델을 인터넷에서 처음부터 다시 받아야 했던 것이 처리
시간 지연의 실질적인 원인 중 하나였습니다.

## 작업내용 ⌨️

- `Dockerfile`: 빌드 단계에서 `pnpm --filter=@repo/ocr-lambda exec kordoc check-ocr-models`로
  OCR 모델을 미리 받아 이미지 안(`/opt/kordoc-models`)에 포함시키고, 런타임에도 같은 경로를
  가리키도록 `KORDOC_MODEL_CACHE` 환경변수를 설정하였습니다.
- `README.md`: 예시 배포 명령어의 `KORDOC_MODEL_CACHE` 값을 갱신하고, 이미 배포된 함수가
  있다면 이미지 갱신만으로는 부족하며 `aws lambda update-function-configuration`으로 환경변수도
  함께 갱신해야 한다는 점을 안내하였습니다.

로컬에서 `pnpm --filter=@repo/ocr-lambda exec kordoc check-ocr-models` 명령을 직접 실행해
모델 다운로드와 SHA-256 검증이 정상적으로 끝나는 것을 확인하였고, 캐시 디렉터리를 읽기
전용으로 만든 뒤 재실행해도 재다운로드 없이 정상 인식되는 것을 확인하였습니다(Lambda 이미지의
읽기 전용 파일시스템 환경 재현). `check-types`/`lint`도 통과합니다.

## 관련 이슈 🚨

#473

## 리뷰 요청사항 👀

- 이 변경은 새 Docker 이미지를 ECR에 올리고 실제 Lambda 함수의 코드·환경변수를 갱신해야
  효과가 적용됩니다(자동 배포 파이프라인 없음). 배포 권한이 있는 분의 확인이 필요합니다.
- 이슈에 있던 나머지 두 문제(출결 미인정/인정 합산, 예체능 정확도)는 이번 PR 범위에
  포함하지 않았습니다. 출결 합산은 백엔드(`MiddleSchoolRecordParser`)의 로직으로 보여 이
  저장소에서 고칠 수 없었고, 예체능 정확도는 `subjectTokenizer.ts`의 과목명 분리 로직이
  과거 실패 사례를 근거로 이미 신중하게 튜닝되어 있어, 실제 실패 샘플 없이 되돌렸다가
  기존에 고쳐둔 버그를 재발시킬 위험이 있어 보류하였습니다.
