### PR TITLE
[guide] 결과 발표 전형별 반영 비율 수정

### DIFF
--- a/apps/client/src/pageContainer/GuidePage/index.tsx
+++ b/apps/client/src/pageContainer/GuidePage/index.tsx
@@ -128,7 +128,7 @@ const Elements: ElementType[] = [
     description: (
       <>
         <strong className={cn('font-semibold')}>
-          1차 서류심사(50%)와 2차 역량검사(30%), 심층면접(20%)
+          1차 서류심사(60%)와 2차 역량검사(20%), 심층면접(20%)
         </strong>
         를 통해 최종 합격자를 선발합니다.
       </>


### PR DESCRIPTION
## 개요 💡

원서 접수 안내 페이지의 `결과 발표` 섹션에 표기된 전형별 반영 비율이 실제 비율과 달라 수정하였습니다.

## 작업내용 ⌨️

- `GuidePage/index.tsx`의 `결과 발표` 항목 설명 문구를 수정하였습니다.
- 1차 서류심사 비율을 `50%`에서 `60%`로 변경하였습니다.
- 2차 역량검사 비율을 `30%`에서 `20%`로 변경하였습니다.
- 심층면접 비율은 `20%`로 변경 없이 유지하였습니다.

## 스크린샷/동영상 📸
<img width="772" height="182" alt="image" src="https://github.com/user-attachments/assets/64cbe033-ba3d-43c5-b951-6b307c0e99ae" />

## 관련 이슈 🚨

closes #487
